### PR TITLE
Remove file with malformed name and expose offline.figToBuffer()

### DIFF
--- a/graph_objects/plot-schema?format=json&sha1=11b662302a42aa0698df091a9974ac8f6e1a2292
+++ b/graph_objects/plot-schema?format=json&sha1=11b662302a42aa0698df091a9974ac8f6e1a2292
@@ -1,1 +1,0 @@
-{"sha1":"11b662302a42aa0698df091a9974ac8f6e1a2292","modified":false}

--- a/offline/plot.go
+++ b/offline/plot.go
@@ -19,18 +19,19 @@ type Options struct {
 
 // ToHtml saves the figure as standalone HTML. It still requires internet to load plotly.js from CDN.
 func ToHtml(fig *grob.Fig, path string) {
-	buf := figToBuffer(fig)
+	buf := FigToBuffer(fig)
 	ioutil.WriteFile(path, buf.Bytes(), os.ModePerm)
 }
 
 // Show displays the figure in your browser.
 // Use serve if you want a persistent view
 func Show(fig *grob.Fig) {
-	buf := figToBuffer(fig)
+	buf := FigToBuffer(fig)
 	browser.OpenReader(buf)
 }
 
-func figToBuffer(fig *grob.Fig) *bytes.Buffer {
+// FigToBuffer creates a byte buffer of the html file for a given figure
+func FigToBuffer(fig *grob.Fig) *bytes.Buffer {
 	figBytes, err := json.Marshal(fig)
 	if err != nil {
 		panic(err)
@@ -57,7 +58,7 @@ func Serve(fig *grob.Fig, opt ...Options) {
 		Addr:    opts.Addr,
 	}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		buf := figToBuffer(fig)
+		buf := FigToBuffer(fig)
 		buf.WriteTo(w)
 	})
 


### PR DESCRIPTION
The [last commit](https://github.com/MetalBlueberry/go-plotly/commit/2e3261a23d0f6b44a049ff960c3c898227220cb4) to this repo prevented cloning the repo and any go gets due to a malformed file name the contained a checksum. I'm not sure why it was there because I can not find any reference to it. Maybe it was left out of the .gitignore? If this is the case I can add that onto this pr.

This pr also includes exporting the offline.figToBuffer() function. This function being exporting would enable using this library in use cases where writing to a file or serving an html file isn't an option. (Ex. WASM)

TL;DR
- removed file plot-schema?format=json&sha1=11b662302a42aa0698df091a9974ac8f6e1a2292 to allow go gets and repo cloning
- exported offline.figToBuffer() for custom use cases