### PR TITLE
layout: fix generated axis type LayoutXaxis

### DIFF
--- a/generator/renderer.go
+++ b/generator/renderer.go
@@ -249,14 +249,12 @@ func (r *Renderer) WriteLayout(w io.Writer) error {
 				Name:        fmt.Sprintf("%sAxis%d", label, i),
 				Description: []string{fmt.Sprintf("%s Axis number %d", label, i)},
 				JSONName:    strings.ToLower(fmt.Sprintf("%saxis%d", label, i)),
-				Type:        fmt.Sprintf("Layout%saxis", label),
+				Type:        fmt.Sprintf("* Layout%saxis", label),
 			})
 		}
 	}
 
-	fmt.Fprint(w, `package grob
-
-`, doNotEdit)
+	fmt.Fprint(w, "package grob\n\n", doNotEdit)
 
 	err = r.tmpl.ExecuteTemplate(w, "trace.tmpl", traceFile.MainType)
 	if err != nil {

--- a/graph_objects/layout_gen.go
+++ b/graph_objects/layout_gen.go
@@ -32,7 +32,7 @@ type Layout struct {
 	// Bargap
 	// arrayOK: false
 	// type: number
-	// Sets the gap (in plot fraction) between bars of adjacent location coordinates.
+	// Sets the gap between bars of adjacent location coordinates. Values are unitless, they represent fractions of the minimum difference in bar positions in the data.
 	Bargap float64 `json:"bargap,omitempty"`
 
 	// Bargroupgap
@@ -441,43 +441,43 @@ type Layout struct {
 
 	// XAxis2
 	// X Axis number 2
-	XAxis2 LayoutXaxis `json:"xaxis2,omitempty"`
+	XAxis2 *LayoutXaxis `json:"xaxis2,omitempty"`
 
 	// XAxis3
 	// X Axis number 3
-	XAxis3 LayoutXaxis `json:"xaxis3,omitempty"`
+	XAxis3 *LayoutXaxis `json:"xaxis3,omitempty"`
 
 	// XAxis4
 	// X Axis number 4
-	XAxis4 LayoutXaxis `json:"xaxis4,omitempty"`
+	XAxis4 *LayoutXaxis `json:"xaxis4,omitempty"`
 
 	// XAxis5
 	// X Axis number 5
-	XAxis5 LayoutXaxis `json:"xaxis5,omitempty"`
+	XAxis5 *LayoutXaxis `json:"xaxis5,omitempty"`
 
 	// XAxis6
 	// X Axis number 6
-	XAxis6 LayoutXaxis `json:"xaxis6,omitempty"`
+	XAxis6 *LayoutXaxis `json:"xaxis6,omitempty"`
 
 	// YAxis2
 	// Y Axis number 2
-	YAxis2 LayoutYaxis `json:"yaxis2,omitempty"`
+	YAxis2 *LayoutYaxis `json:"yaxis2,omitempty"`
 
 	// YAxis3
 	// Y Axis number 3
-	YAxis3 LayoutYaxis `json:"yaxis3,omitempty"`
+	YAxis3 *LayoutYaxis `json:"yaxis3,omitempty"`
 
 	// YAxis4
 	// Y Axis number 4
-	YAxis4 LayoutYaxis `json:"yaxis4,omitempty"`
+	YAxis4 *LayoutYaxis `json:"yaxis4,omitempty"`
 
 	// YAxis5
 	// Y Axis number 5
-	YAxis5 LayoutYaxis `json:"yaxis5,omitempty"`
+	YAxis5 *LayoutYaxis `json:"yaxis5,omitempty"`
 
 	// YAxis6
 	// Y Axis number 6
-	YAxis6 LayoutYaxis `json:"yaxis6,omitempty"`
+	YAxis6 *LayoutYaxis `json:"yaxis6,omitempty"`
 }
 
 // LayoutActiveshape
@@ -6300,38 +6300,38 @@ const (
 type LayoutBarmode string
 
 const (
+	HistogramBarmodeStack    LayoutBarmode = "stack"
+	HistogramBarmodeGroup    LayoutBarmode = "group"
+	HistogramBarmodeOverlay  LayoutBarmode = "overlay"
+	HistogramBarmodeRelative LayoutBarmode = "relative"
 	BarBarmodeStack          LayoutBarmode = "stack"
 	BarBarmodeGroup          LayoutBarmode = "group"
 	BarBarmodeOverlay        LayoutBarmode = "overlay"
 	BarBarmodeRelative       LayoutBarmode = "relative"
 	BarpolarBarmodeStack     LayoutBarmode = "stack"
 	BarpolarBarmodeOverlay   LayoutBarmode = "overlay"
-	HistogramBarmodeStack    LayoutBarmode = "stack"
-	HistogramBarmodeGroup    LayoutBarmode = "group"
-	HistogramBarmodeOverlay  LayoutBarmode = "overlay"
-	HistogramBarmodeRelative LayoutBarmode = "relative"
 )
 
 // LayoutBarnorm Sets the normalization for bar traces on the graph. With *fraction*, the value of each bar is divided by the sum of all values at that location coordinate. *percent* is the same but multiplied by 100 to show percentages.
 type LayoutBarnorm string
 
 const (
-	HistogramBarnormEmpty    LayoutBarnorm = ""
-	HistogramBarnormFraction LayoutBarnorm = "fraction"
-	HistogramBarnormPercent  LayoutBarnorm = "percent"
 	BarBarnormEmpty          LayoutBarnorm = ""
 	BarBarnormFraction       LayoutBarnorm = "fraction"
 	BarBarnormPercent        LayoutBarnorm = "percent"
+	HistogramBarnormEmpty    LayoutBarnorm = ""
+	HistogramBarnormFraction LayoutBarnorm = "fraction"
+	HistogramBarnormPercent  LayoutBarnorm = "percent"
 )
 
 // LayoutBoxmode Determines how boxes at the same location coordinate are displayed on the graph. If *group*, the boxes are plotted next to one another centered around the shared location. If *overlay*, the boxes are plotted over one another, you might need to set *opacity* to see them multiple boxes. Has no effect on traces that have *width* set.
 type LayoutBoxmode string
 
 const (
-	BoxBoxmodeGroup           LayoutBoxmode = "group"
-	BoxBoxmodeOverlay         LayoutBoxmode = "overlay"
 	CandlestickBoxmodeGroup   LayoutBoxmode = "group"
 	CandlestickBoxmodeOverlay LayoutBoxmode = "overlay"
+	BoxBoxmodeGroup           LayoutBoxmode = "group"
+	BoxBoxmodeOverlay         LayoutBoxmode = "overlay"
 )
 
 // LayoutCalendar Sets the default calendar system to use for interpreting and displaying dates throughout the plot.


### PR DESCRIPTION
fix axis type to remove unnecessary generation from html files. 

<img width="1278" alt="Screenshot 2023-02-11 at 20 32 41" src="https://user-images.githubusercontent.com/26767094/218277662-c18b48ba-ff3f-405e-8149-307ee8d0cb00.png">

