### PR TITLE
Implement DataArray type

### DIFF
--- a/examples/animation/animation.go
+++ b/examples/animation/animation.go
@@ -37,7 +37,7 @@ func main() {
 		frames = append(frames, grob.Frame{
 			Data: []types.Trace{
 				&grob.Scatter{
-					Y: []float64{rand.Float64(), rand.Float64(), rand.Float64()},
+					Y: types.DataArray([]float64{rand.Float64(), rand.Float64(), rand.Float64()}),
 				},
 			},
 		})
@@ -46,8 +46,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter{
-				X: []float64{1, 2, 3},
-				Y: []float64{0, 0.5, 1},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{0, 0.5, 1}),
 				Line: &grob.ScatterLine{
 					Simplify: types.False,
 				},

--- a/examples/bar.html
+++ b/examples/bar.html
@@ -1,11 +1,11 @@
 
 	<head>
-		<script src="https://cdn.plot.ly/plotly-2.31.1.min.js"></script>
+		<script src="https://cdn.plot.ly/plotly-2.34.0.min.js"></script>
 	</head>
 	<body>
 		<div id="plot"></div>
 	<script>
-		data = JSON.parse(atob('eyJkYXRhIjpbeyJ0eXBlIjoiYmFyIiwiYmFzZSI6bnVsbCwiaG92ZXJpbmZvIjpudWxsLCJob3ZlcnRlbXBsYXRlIjpudWxsLCJob3ZlcnRleHQiOm51bGwsIm1ldGEiOm51bGwsIm9mZnNldCI6bnVsbCwidGV4dCI6bnVsbCwidGV4dHBvc2l0aW9uIjpudWxsLCJ0ZXh0dGVtcGxhdGUiOm51bGwsIndpZHRoIjpudWxsLCJ4IjpbMSwyLDNdLCJ5IjpbMSwyLDNdfV0sImxheW91dCI6eyJtZXRhIjpudWxsLCJ0aXRsZSI6eyJ0ZXh0IjoiQSBGaWd1cmUgJ1NwZWNpZmllZCcgQnkgR28gU3RydWN0In19fQ=='))
+		data = JSON.parse(atob('eyJkYXRhIjpbeyJ0eXBlIjoiYmFyIiwieCI6WzEsMiwzXSwieSI6WzEsMiwzXX1dLCJsYXlvdXQiOnsidGl0bGUiOnsic3VidGl0bGUiOnsidGV4dCI6IkFtYXppbmcifSwidGV4dCI6IkEgRmlndXJlIFNwZWNpZmllZCBCeSBHbyBTdHJ1Y3QifX19'))
 		Plotly.newPlot('plot', data);
 	</script>
 	</body>

--- a/examples/bar/main.go
+++ b/examples/bar/main.go
@@ -18,8 +18,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Bar{
-				X: []float64{1, 2, 3},
-				Y: []float64{1, 2, 3},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{1, 2, 3}),
 			},
 		},
 		Layout: &grob.Layout{

--- a/examples/bar_custom/main.go
+++ b/examples/bar_custom/main.go
@@ -52,8 +52,8 @@ func main() {
 	}
 
 	trace1 := &grob.Bar{
-		X:            xValue,
-		Y:            yValue,
+		X:            types.DataArray(xValue),
+		Y:            types.DataArray(yValue),
 		Text:         types.ArrayOKArray(toString(yValue)...),
 		Textposition: types.ArrayOKValue(grob.BarTextpositionAuto),
 		Hoverinfo:    types.ArrayOKValue(grob.BarHoverinfoNone),

--- a/examples/colorscale/main.go
+++ b/examples/colorscale/main.go
@@ -16,9 +16,9 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter3d{
-				X:    x,
-				Y:    y,
-				Z:    z,
+				X:    types.DataArray(x),
+				Y:    types.DataArray(y),
+				Z:    types.DataArray(z),
 				Mode: grob.Scatter3dModeMarkers,
 				Marker: &grob.Scatter3dMarker{
 					Autocolorscale: types.False,

--- a/examples/numpy_bdata/Dockerfile
+++ b/examples/numpy_bdata/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN pip install numpy
+
+COPY compute.py .
+
+CMD ["python", "compute.py"]

--- a/examples/numpy_bdata/Makefile
+++ b/examples/numpy_bdata/Makefile
@@ -1,0 +1,14 @@
+IMAGE_NAME = plotly-data-generator
+
+all: build run
+
+build:
+	@docker build -t $(IMAGE_NAME) .
+
+run:
+	@docker run --rm $(IMAGE_NAME)
+
+
+
+clean:
+	@docker rmi $(IMAGE_NAME)

--- a/examples/numpy_bdata/compute.py
+++ b/examples/numpy_bdata/compute.py
@@ -1,0 +1,33 @@
+import numpy as np
+import json
+import base64
+
+# Generate Z data using NumPy
+# Let's create a similar 3x5 matrix with some values
+z = np.array([
+    [1, np.nan, 30, 50, 1],
+    [20, 1, 60, 80, 30],
+    [30, 60, 1, -10, 20]
+])
+
+
+
+dtype = z.dtype
+bdata = z.tobytes()  # Binary data representation
+shape = z.shape
+
+# Encode the binary data as a base64 string
+z_bdata_base64 = base64.b64encode(bdata).decode('utf-8')
+
+# Create the dictionary that represents the JSON object
+z_data = {
+    'dtype': str(dtype),
+    'shape': shape,
+    'bdata': z_bdata_base64 
+}
+
+# Convert the dictionary to a JSON object
+json_data = json.dumps(z_data, indent=2)
+
+# Output the JSON object
+print(json_data)

--- a/examples/numpy_bdata/main.go
+++ b/examples/numpy_bdata/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	grob "github.com/MetalBlueberry/go-plotly/generated/v2.31.1/graph_objects"
+	"github.com/MetalBlueberry/go-plotly/pkg/offline"
+	"github.com/MetalBlueberry/go-plotly/pkg/types"
+)
+
+func main() {
+	// https://plotly.com/javascript/heatmaps/
+	// var data = [
+	//   {
+	//     z: [[1, null, 30, 50, 1], [20, 1, 60, 80, 30], [30, 60, 1, -10, 20]],
+	//     x: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+	//     y: ['Morning', 'Afternoon', 'Evening'],
+	//     type: 'heatmap',
+	//     hoverongaps: false
+	//   }
+	// ];
+	zJSON, err := exec.Command("make").Output()
+	if err != nil {
+		panic(err)
+	}
+	type bdata struct {
+		DType types.DType
+		Shape []int
+		BData []byte
+	}
+
+	z := &bdata{}
+	err = json.Unmarshal(zJSON, z)
+	if err != nil {
+		panic(err)
+	}
+
+	fig := &grob.Fig{
+		Data: []types.Trace{
+			&grob.Heatmap{
+				X:           types.DataArray([]string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday"}),
+				Y:           types.DataArray([]string{"Morning", "Afternoon", "Evening"}),
+				Z:           types.BDataArray(z.DType, z.BData, z.Shape),
+				Hoverongaps: types.False,
+			},
+		},
+	}
+
+	offline.Show(fig)
+
+}

--- a/examples/range_slider/main.go
+++ b/examples/range_slider/main.go
@@ -80,8 +80,8 @@ func main() {
 
 	fig := &grob.Fig{}
 	fig.Data = append(fig.Data, &grob.Scatter{
-		X: df.Col("Date").Records(),
-		Y: df.Col("High").Float(),
+		X: types.DataArray(df.Col("Date").Records()),
+		Y: types.DataArray(df.Col("High").Float()),
 	})
 
 	fig.Layout = &grob.Layout{

--- a/examples/responsive/main.go
+++ b/examples/responsive/main.go
@@ -18,8 +18,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Bar{
-				X: []float64{1, 2, 3},
-				Y: []float64{1, 2, 3},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{1, 2, 3}),
 			},
 		},
 		Layout: &grob.Layout{

--- a/examples/scatter/main.go
+++ b/examples/scatter/main.go
@@ -27,8 +27,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter{
-				X:    t,
-				Y:    y,
+				X:    types.DataArray(t),
+				Y:    types.DataArray(y),
 				Mode: grob.ScatterModeMarkers,
 			},
 		},

--- a/examples/scatter3d/main.go
+++ b/examples/scatter3d/main.go
@@ -30,9 +30,9 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter3d{
-				X:    x,
-				Y:    y,
-				Z:    z,
+				X:    types.DataArray(x),
+				Y:    types.DataArray(y),
+				Z:    types.DataArray(z),
 				Mode: grob.Scatter3dModeMarkers,
 			},
 		},

--- a/examples/stargazers/main.go
+++ b/examples/stargazers/main.go
@@ -69,8 +69,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter{
-				X:    x,
-				Y:    y,
+				X:    types.DataArray(x),
+				Y:    types.DataArray(y),
 				Text: types.ArrayOKArray(text...),
 				Meta: types.ArrayOKArray(link...),
 				Mode: grob.ScatterModeLines + "+" + grob.ScatterModeMarkers,

--- a/examples/static_image/main.go
+++ b/examples/static_image/main.go
@@ -24,8 +24,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Bar{
-				X: []float64{1, 2, 3},
-				Y: []float64{1, 2, 3},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{1, 2, 3}),
 			},
 		},
 		Layout: &grob.Layout{

--- a/examples/subplots_share_axes/main.go
+++ b/examples/subplots_share_axes/main.go
@@ -56,24 +56,24 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter{
-				X: []float64{1, 2, 3},
-				Y: []float64{2, 3, 4},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{2, 3, 4}),
 			},
 			&grob.Scatter{
-				X:     []float64{20, 30, 40},
-				Y:     []float64{5, 5, 5},
+				X:     types.DataArray([]float64{20, 30, 40}),
+				Y:     types.DataArray([]float64{5, 5, 5}),
 				Xaxis: "x2",
 				Yaxis: "y",
 			},
 			&grob.Scatter{
-				X:     []float64{2, 3, 4},
-				Y:     []float64{600, 700, 800},
+				X:     types.DataArray([]float64{2, 3, 4}),
+				Y:     types.DataArray([]float64{600, 700, 800}),
 				Xaxis: "x",
 				Yaxis: "y3",
 			},
 			&grob.Scatter{
-				X:     []float64{4000, 5000, 6000},
-				Y:     []float64{7000, 8000, 9000},
+				X:     types.DataArray([]float64{4000, 5000, 6000}),
+				Y:     types.DataArray([]float64{7000, 8000, 9000}),
 				Xaxis: "x4",
 				Yaxis: "y4",
 			},

--- a/examples/transforms/main.go
+++ b/examples/transforms/main.go
@@ -18,8 +18,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Bar{
-				X: []float64{1, 2, 3},
-				Y: []float64{1, 2, 3},
+				X: types.DataArray([]float64{1, 2, 3}),
+				Y: types.DataArray([]float64{1, 2, 3}),
 			},
 		},
 		Layout: &grob.Layout{

--- a/examples/unmarshal/main.go
+++ b/examples/unmarshal/main.go
@@ -16,8 +16,8 @@ func main() {
 	fig := &grob.Fig{
 		Data: []types.Trace{
 			&grob.Scatter{
-				X:    t,
-				Y:    y,
+				X:    types.DataArray(t),
+				Y:    types.DataArray(y),
 				Mode: grob.ScatterModeMarkers,
 			},
 		},

--- a/examples/waterfall_bar_chart/main.go
+++ b/examples/waterfall_bar_chart/main.go
@@ -122,8 +122,8 @@ func main() {
 	// Base
 
 	trace1 := &grob.Bar{
-		X: xData,
-		Y: []int{0, 430, 0, 570, 370, 370, 0},
+		X: types.DataArray(xData),
+		Y: types.DataArray([]int{0, 430, 0, 570, 370, 370, 0}),
 		Marker: &grob.BarMarker{
 			Color: types.ArrayOKValue(types.UseColor("rgba(1,1,1,0.0)")),
 		},
@@ -132,8 +132,8 @@ func main() {
 	// Revenue
 
 	trace2 := &grob.Bar{
-		X: xData,
-		Y: []int{430, 260, 690, 0, 0, 0, 0},
+		X: types.DataArray(xData),
+		Y: types.DataArray([]int{430, 260, 690, 0, 0, 0, 0}),
 		Marker: &grob.BarMarker{
 			Color: types.ArrayOKValue(types.UseColor("rgba(55,128,191,0.7)")),
 			Line: &grob.BarMarkerLine{
@@ -146,8 +146,8 @@ func main() {
 	// Cost
 
 	trace3 := &grob.Bar{
-		X: xData,
-		Y: []int{0, 0, 0, 120, 200, 320, 0},
+		X: types.DataArray(xData),
+		Y: types.DataArray([]int{0, 0, 0, 120, 200, 320, 0}),
 		Marker: &grob.BarMarker{
 			Color: types.ArrayOKValue(types.UseColor("rgba(219, 64, 82, 0.7)")),
 			Line: &grob.BarMarkerLine{
@@ -160,8 +160,8 @@ func main() {
 	// Profit
 
 	trace4 := &grob.Bar{
-		X: xData,
-		Y: []int{0, 0, 0, 0, 0, 0, 370},
+		X: types.DataArray(xData),
+		Y: types.DataArray([]int{0, 0, 0, 0, 0, 0, 370}),
 		Marker: &grob.BarMarker{
 			Color: types.ArrayOKValue(types.UseColor("rgba(50,171, 96, 0.7)")),
 			Line: &grob.BarMarkerLine{

--- a/generated/v2.19.0/graph_objects/bar_gen.go
+++ b/generated/v2.19.0/graph_objects/bar_gen.go
@@ -63,7 +63,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -139,7 +141,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -356,7 +360,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -412,7 +418,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -472,13 +480,17 @@ type BarErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -567,13 +579,17 @@ type BarErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1144,7 +1160,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1156,7 +1174,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/barpolar_gen.go
+++ b/generated/v2.19.0/graph_objects/barpolar_gen.go
@@ -44,7 +44,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -110,7 +112,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -186,7 +190,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -244,7 +250,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -762,7 +770,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -774,7 +784,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/box_gen.go
+++ b/generated/v2.19.0/graph_objects/box_gen.go
@@ -52,7 +52,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -131,7 +133,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -177,7 +181,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the lower fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `lowerfence` is not provided but a sample (in `y` or `x`) is set, we compute the lower as the last sample point below 1.5 times the IQR.
-	Lowerfence interface{} `json:"lowerfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lowerfence *types.DataArrayType `json:"lowerfence,omitempty"`
 
 	// Lowerfencesrc
 	// arrayOK: false
@@ -194,7 +200,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the mean values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `mean` is not provided but a sample (in `y` or `x`) is set, we compute the mean for each box using the sample values.
-	Mean interface{} `json:"mean,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Mean *types.DataArrayType `json:"mean,omitempty"`
 
 	// Meansrc
 	// arrayOK: false
@@ -206,7 +214,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the median values. There should be as many items as the number of boxes desired.
-	Median interface{} `json:"median,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Median *types.DataArrayType `json:"median,omitempty"`
 
 	// Mediansrc
 	// arrayOK: false
@@ -242,7 +252,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the notch span from the boxes' `median` values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `notchspan` is not provided but a sample (in `y` or `x`) is set, we compute it as 1.57 * IQR / sqrt(N), where N is the sample size.
-	Notchspan interface{} `json:"notchspan,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Notchspan *types.DataArrayType `json:"notchspan,omitempty"`
 
 	// Notchspansrc
 	// arrayOK: false
@@ -285,7 +297,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 1 values. There should be as many items as the number of boxes desired.
-	Q1 interface{} `json:"q1,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q1 *types.DataArrayType `json:"q1,omitempty"`
 
 	// Q1src
 	// arrayOK: false
@@ -297,7 +311,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 3 values. There should be as many items as the number of boxes desired.
-	Q3 interface{} `json:"q3,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q3 *types.DataArrayType `json:"q3,omitempty"`
 
 	// Q3src
 	// arrayOK: false
@@ -316,7 +332,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the standard deviation values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `sd` is not provided but a sample (in `y` or `x`) is set, we compute the standard deviation for each box using the sample values.
-	Sd interface{} `json:"sd,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Sd *types.DataArrayType `json:"sd,omitempty"`
 
 	// Sdsrc
 	// arrayOK: false
@@ -384,7 +402,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the upper fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `upperfence` is not provided but a sample (in `y` or `x`) is set, we compute the lower as the last sample point above 1.5 times the IQR.
-	Upperfence interface{} `json:"upperfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Upperfence *types.DataArrayType `json:"upperfence,omitempty"`
 
 	// Upperfencesrc
 	// arrayOK: false
@@ -415,7 +435,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -471,7 +493,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/candlestick_gen.go
+++ b/generated/v2.19.0/graph_objects/candlestick_gen.go
@@ -32,7 +32,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -148,7 +156,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -184,7 +194,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -255,7 +267,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/carpet_gen.go
+++ b/generated/v2.19.0/graph_objects/carpet_gen.go
@@ -32,7 +32,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing values of the first parameter value
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -55,7 +57,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -96,7 +100,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -125,7 +131,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -202,7 +210,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of x coordinates at each carpet point. If omitted, the plot is a cheater plot and the xaxis is hidden by default.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -220,7 +230,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -367,7 +379,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -656,7 +670,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -668,7 +684,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -821,7 +839,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -1110,7 +1130,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1122,7 +1144,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/choropleth_gen.go
+++ b/generated/v2.19.0/graph_objects/choropleth_gen.go
@@ -55,7 +55,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -169,7 +173,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -279,7 +285,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -632,7 +640,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -644,7 +654,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/choroplethmapbox_gen.go
+++ b/generated/v2.19.0/graph_objects/choroplethmapbox_gen.go
@@ -61,7 +61,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -162,7 +166,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets which features found in *geojson* to plot using their feature `id` field.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -278,7 +284,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -631,7 +639,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -643,7 +653,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/cone_gen.go
+++ b/generated/v2.19.0/graph_objects/cone_gen.go
@@ -86,7 +86,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -263,7 +267,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -293,7 +299,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -318,7 +326,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -336,7 +346,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field and of the displayed cones.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -354,7 +366,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field and of the displayed cones.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -372,7 +386,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field and of the displayed cones.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -707,7 +723,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -719,7 +737,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/contour_gen.go
+++ b/generated/v2.19.0/graph_objects/contour_gen.go
@@ -72,7 +72,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -138,7 +140,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -150,7 +154,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -243,7 +249,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -296,7 +304,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -359,7 +369,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -422,7 +434,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -781,7 +795,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -793,7 +809,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/contourcarpet_gen.go
+++ b/generated/v2.19.0/graph_objects/contourcarpet_gen.go
@@ -32,7 +32,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -69,7 +71,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +158,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -164,7 +172,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -257,7 +267,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -306,7 +318,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -659,7 +673,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -671,7 +687,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/densitymapbox_gen.go
+++ b/generated/v2.19.0/graph_objects/densitymapbox_gen.go
@@ -61,7 +61,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -127,7 +131,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -162,7 +168,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -275,7 +283,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the points' weight. For example, a value of 10 would be equivalent to having 10 points of weight 1 in the same spot
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -628,7 +638,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -640,7 +652,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/funnel_gen.go
+++ b/generated/v2.19.0/graph_objects/funnel_gen.go
@@ -56,7 +56,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -122,7 +124,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -324,7 +328,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -373,7 +379,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -957,7 +965,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -969,7 +979,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/funnelarea_gen.go
+++ b/generated/v2.19.0/graph_objects/funnelarea_gen.go
@@ -44,7 +44,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -109,7 +111,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -132,7 +136,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -213,7 +219,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -284,7 +292,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -538,7 +548,9 @@ type FunnelareaMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/heatmap_gen.go
+++ b/generated/v2.19.0/graph_objects/heatmap_gen.go
@@ -61,7 +61,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -121,7 +123,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -133,7 +137,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -268,7 +276,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -337,7 +347,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -406,7 +418,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -772,7 +786,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -784,7 +800,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/heatmapgl_gen.go
+++ b/generated/v2.19.0/graph_objects/heatmapgl_gen.go
@@ -55,7 +55,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -97,7 +99,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -167,7 +171,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -209,7 +215,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -240,7 +248,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -271,7 +281,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -631,7 +643,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -643,7 +657,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/histogram2d_gen.go
+++ b/generated/v2.19.0/graph_objects/histogram2d_gen.go
@@ -73,7 +73,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -129,7 +131,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -263,7 +267,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -311,7 +317,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -359,7 +367,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -725,7 +735,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -737,7 +749,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -937,7 +951,9 @@ type Histogram2dMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/histogram2dcontour_gen.go
+++ b/generated/v2.19.0/graph_objects/histogram2dcontour_gen.go
@@ -84,7 +84,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -285,7 +289,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -327,7 +333,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -369,7 +377,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -728,7 +738,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -740,7 +752,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1062,7 +1076,9 @@ type Histogram2dcontourMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/histogram_gen.go
+++ b/generated/v2.19.0/graph_objects/histogram_gen.go
@@ -74,7 +74,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +154,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -345,7 +349,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -381,7 +387,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -445,13 +453,17 @@ type HistogramErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -540,13 +552,17 @@ type HistogramErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1099,7 +1115,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1111,7 +1129,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/icicle_gen.go
+++ b/generated/v2.19.0/graph_objects/icicle_gen.go
@@ -46,7 +46,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -202,7 +208,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -235,7 +243,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -300,7 +310,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -849,7 +861,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -861,7 +875,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -995,7 +1011,9 @@ type IcicleMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/image_gen.go
+++ b/generated/v2.19.0/graph_objects/image_gen.go
@@ -39,7 +39,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -93,7 +95,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -105,7 +109,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -169,7 +175,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -224,7 +232,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// A 2-dimensional array in which each element is an array of 3 or 4 numbers representing a color.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zmax
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/indicator_gen.go
+++ b/generated/v2.19.0/graph_objects/indicator_gen.go
@@ -39,7 +39,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -66,7 +68,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -505,7 +509,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -517,7 +523,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/isosurface_gen.go
+++ b/generated/v2.19.0/graph_objects/isosurface_gen.go
@@ -89,7 +89,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -298,7 +302,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -323,7 +329,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -341,7 +349,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -359,7 +369,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -761,7 +773,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -773,7 +787,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1069,7 +1085,9 @@ type IsosurfaceSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1097,7 +1115,9 @@ type IsosurfaceSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1125,7 +1145,9 @@ type IsosurfaceSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/layout_gen.go
+++ b/generated/v2.19.0/graph_objects/layout_gen.go
@@ -217,7 +217,9 @@ type Layout struct {
 	// arrayOK: false
 	// type: data_array
 	// hiddenlabels is the funnelarea & pie chart analog of visible:'legendonly' but it can contain many labels, and can simultaneously hide slices from several pies/funnelarea charts
-	Hiddenlabels interface{} `json:"hiddenlabels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hiddenlabels *types.DataArrayType `json:"hiddenlabels,omitempty"`
 
 	// Hiddenlabelssrc
 	// arrayOK: false
@@ -1237,7 +1239,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1249,7 +1253,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -2408,7 +2414,9 @@ type LayerLine struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the length of dashes and gaps (mapbox.layer.paint.line-dasharray). Has an effect only when `type` is set to *line*.
-	Dash interface{} `json:"dash,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Dash *types.DataArrayType `json:"dash,omitempty"`
 
 	// Dashsrc
 	// arrayOK: false
@@ -3002,7 +3010,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3244,7 +3254,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3256,7 +3268,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -3445,7 +3459,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3681,7 +3697,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3693,7 +3711,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -4289,7 +4309,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -4542,7 +4564,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -4554,7 +4578,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -4732,7 +4758,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -4985,7 +5013,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -4997,7 +5027,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5175,7 +5207,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5428,7 +5462,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5440,7 +5476,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6404,7 +6442,9 @@ type LayoutSmithImaginaryaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Defaults to `realaxis.tickvals` plus the same as negatives and zero.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6596,7 +6636,9 @@ type LayoutSmithRealaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6945,7 +6987,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -6957,7 +7001,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7286,7 +7332,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7298,7 +7346,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7627,7 +7677,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7639,7 +7691,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8171,7 +8225,9 @@ type LayoutXaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8582,7 +8638,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -8988,7 +9046,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9000,7 +9060,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9132,7 +9194,9 @@ type LayoutYaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9341,7 +9405,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -9743,7 +9809,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9755,7 +9823,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/mesh3d_gen.go
+++ b/generated/v2.19.0/graph_objects/mesh3d_gen.go
@@ -96,7 +96,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each face Overrides *color* and *vertexcolor*.
-	Facecolor interface{} `json:"facecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Facecolor *types.DataArrayType `json:"facecolor,omitempty"`
 
 	// Facecolorsrc
 	// arrayOK: false
@@ -175,13 +179,17 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *first* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `i[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `i` represents a point in space, which is the first vertex of a triangle.
-	I interface{} `json:"i,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	I *types.DataArrayType `json:"i,omitempty"`
 
 	// Ids
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -193,7 +201,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the intensity values for vertices or cells as defined by `intensitymode`. It can be used for plotting fields on meshes.
-	Intensity interface{} `json:"intensity,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Intensity *types.DataArrayType `json:"intensity,omitempty"`
 
 	// Intensitymode
 	// arrayOK: false
@@ -218,7 +228,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *second* vertex of a triangle. For example, `{i[m], j[m], k[m]}`  together represent face m (triangle m) in the mesh, where `j[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `j` represents a point in space, which is the second vertex of a triangle.
-	J interface{} `json:"j,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	J *types.DataArrayType `json:"j,omitempty"`
 
 	// Jsrc
 	// arrayOK: false
@@ -230,7 +242,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *third* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `k[m] = n` points to the triplet  `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `k` represents a point in space, which is the third vertex of a triangle.
-	K interface{} `json:"k,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	K *types.DataArrayType `json:"k,omitempty"`
 
 	// Ksrc
 	// arrayOK: false
@@ -352,7 +366,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each vertex Overrides *color*. While Red, green and blue colors are in the range of 0 and 255; in the case of having vertex color data in RGBA format, the alpha color should be normalized to be between 0 and 1.
-	Vertexcolor interface{} `json:"vertexcolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Vertexcolor *types.DataArrayType `json:"vertexcolor,omitempty"`
 
 	// Vertexcolorsrc
 	// arrayOK: false
@@ -371,7 +387,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -396,7 +414,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -421,7 +441,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -763,7 +785,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -775,7 +799,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/ohlc_gen.go
+++ b/generated/v2.19.0/graph_objects/ohlc_gen.go
@@ -32,7 +32,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -148,7 +156,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -184,7 +194,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -255,7 +267,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/parcats_gen.go
+++ b/generated/v2.19.0/graph_objects/parcats_gen.go
@@ -171,7 +171,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories in this dimension appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -202,7 +204,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets alternative tick labels for the categories in this dimension. Only has an effect if `categoryorder` is set to *array*. Should be an array the same length as `categoryarray` Used with `categoryorder`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -214,7 +218,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the category value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated).
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -636,7 +642,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -648,7 +656,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/parcoords_gen.go
+++ b/generated/v2.19.0/graph_objects/parcoords_gen.go
@@ -32,7 +32,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -54,7 +56,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -214,7 +218,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -226,7 +232,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -238,7 +246,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated). Each value must be a finite number.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -660,7 +670,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -672,7 +684,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/pie_gen.go
+++ b/generated/v2.19.0/graph_objects/pie_gen.go
@@ -38,7 +38,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -146,7 +150,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -256,7 +262,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -327,7 +335,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -581,7 +591,9 @@ type PieMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/pointcloud_gen.go
+++ b/generated/v2.19.0/graph_objects/pointcloud_gen.go
@@ -32,7 +32,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -62,7 +64,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -74,7 +78,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// A sequential value, 0..n, supply it to avoid creating this array inside plotting. If specified, it must be a typed `Int32Array` array. Its length must be equal to or greater than the number of points. For the best performance and memory use, create one large `indices` typed array that is guaranteed to be at least as long as the largest number of points during use, and reuse it on each `Plotly.restyle()` call.
-	Indices interface{} `json:"indices,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Indices *types.DataArrayType `json:"indices,omitempty"`
 
 	// Indicessrc
 	// arrayOK: false
@@ -180,7 +186,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -192,7 +200,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `xbounds` in the shape of `[xMin, xMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `ybounds` for the performance benefits.
-	Xbounds interface{} `json:"xbounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xbounds *types.DataArrayType `json:"xbounds,omitempty"`
 
 	// Xboundssrc
 	// arrayOK: false
@@ -210,7 +220,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Faster alternative to specifying `x` and `y` separately. If supplied, it must be a typed `Float32Array` array that represents points such that `xy[i * 2] = x[i]` and `xy[i * 2 + 1] = y[i]`
-	Xy interface{} `json:"xy,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xy *types.DataArrayType `json:"xy,omitempty"`
 
 	// Xysrc
 	// arrayOK: false
@@ -222,7 +234,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -234,7 +248,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `ybounds` in the shape of `[yMin, yMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `xbounds` for the performance benefits.
-	Ybounds interface{} `json:"ybounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ybounds *types.DataArrayType `json:"ybounds,omitempty"`
 
 	// Yboundssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/sankey_gen.go
+++ b/generated/v2.19.0/graph_objects/sankey_gen.go
@@ -39,7 +39,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -68,7 +70,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -535,7 +539,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each link.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -571,7 +577,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the link.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -588,7 +596,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the source node.
-	Source interface{} `json:"source,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Source *types.DataArrayType `json:"source,omitempty"`
 
 	// Sourcesrc
 	// arrayOK: false
@@ -600,7 +610,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the target node.
-	Target interface{} `json:"target,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Target *types.DataArrayType `json:"target,omitempty"`
 
 	// Targetsrc
 	// arrayOK: false
@@ -612,7 +624,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// A numeric value representing the flow volume value.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuesrc
 	// arrayOK: false
@@ -766,7 +780,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each node.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -808,7 +824,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the node.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -837,7 +855,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized horizontal position of the node.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -849,7 +869,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized vertical position of the node.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scatter3d_gen.go
+++ b/generated/v2.19.0/graph_objects/scatter3d_gen.go
@@ -38,7 +38,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -107,7 +109,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -284,7 +288,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -309,7 +315,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -334,7 +342,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -363,13 +373,17 @@ type Scatter3dErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -458,13 +472,17 @@ type Scatter3dErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -553,13 +571,17 @@ type Scatter3dErrorZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1090,7 +1112,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1102,7 +1126,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1568,7 +1594,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1580,7 +1608,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scatter_gen.go
+++ b/generated/v2.19.0/graph_objects/scatter_gen.go
@@ -50,7 +50,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -158,7 +160,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -353,7 +357,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -409,7 +415,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -469,13 +477,17 @@ type ScatterErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -564,13 +576,17 @@ type ScatterErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1232,7 +1248,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1244,7 +1262,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scattercarpet_gen.go
+++ b/generated/v2.19.0/graph_objects/scattercarpet_gen.go
@@ -32,7 +32,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the a-axis coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the b-axis coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -68,7 +72,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -142,7 +148,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -822,7 +830,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -834,7 +844,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scattergeo_gen.go
+++ b/generated/v2.19.0/graph_objects/scattergeo_gen.go
@@ -38,7 +38,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -123,7 +125,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -135,7 +139,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -182,7 +188,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. Coordinates correspond to the centroid of each location given. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -194,7 +202,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -809,7 +819,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -821,7 +833,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scattergl_gen.go
+++ b/generated/v2.19.0/graph_objects/scattergl_gen.go
@@ -38,7 +38,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -296,7 +300,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -352,7 +358,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -412,13 +420,17 @@ type ScatterglErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -507,13 +519,17 @@ type ScatterglErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1074,7 +1090,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1086,7 +1104,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scattermapbox_gen.go
+++ b/generated/v2.19.0/graph_objects/scattermapbox_gen.go
@@ -49,7 +49,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -128,7 +132,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -168,7 +174,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -841,7 +849,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -853,7 +863,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scatterpolar_gen.go
+++ b/generated/v2.19.0/graph_objects/scatterpolar_gen.go
@@ -44,7 +44,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -130,7 +132,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -206,7 +210,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -294,7 +300,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -847,7 +855,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -859,7 +869,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scatterpolargl_gen.go
+++ b/generated/v2.19.0/graph_objects/scatterpolargl_gen.go
@@ -38,7 +38,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -117,7 +119,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -193,7 +197,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -281,7 +287,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -817,7 +825,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -829,7 +839,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scattersmith_gen.go
+++ b/generated/v2.19.0/graph_objects/scattersmith_gen.go
@@ -44,7 +44,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -118,7 +120,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -130,7 +134,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Imag interface{} `json:"imag,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Imag *types.DataArrayType `json:"imag,omitempty"`
 
 	// Imagsrc
 	// arrayOK: false
@@ -206,7 +212,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Real interface{} `json:"real,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Real *types.DataArrayType `json:"real,omitempty"`
 
 	// Realsrc
 	// arrayOK: false
@@ -816,7 +824,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -828,7 +838,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/scatterternary_gen.go
+++ b/generated/v2.19.0/graph_objects/scatterternary_gen.go
@@ -32,7 +32,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -56,7 +60,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	C interface{} `json:"c,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	C *types.DataArrayType `json:"c,omitempty"`
 
 	// Cliponaxis
 	// arrayOK: false
@@ -80,7 +86,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -834,7 +844,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -846,7 +858,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/splom_gen.go
+++ b/generated/v2.19.0/graph_objects/splom_gen.go
@@ -32,7 +32,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -96,7 +98,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -313,7 +317,9 @@ type SplomDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the dimension values to be plotted.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -783,7 +789,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -795,7 +803,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/streamtube_gen.go
+++ b/generated/v2.19.0/graph_objects/streamtube_gen.go
@@ -79,7 +79,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -248,7 +252,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -278,7 +284,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -303,7 +311,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -321,7 +331,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -339,7 +351,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -357,7 +371,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -692,7 +708,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -704,7 +722,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -972,7 +992,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the starting position of the streamtubes
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -984,7 +1006,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the starting position of the streamtubes
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false
@@ -996,7 +1020,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the starting position of the streamtubes
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zsrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/sunburst_gen.go
+++ b/generated/v2.19.0/graph_objects/sunburst_gen.go
@@ -46,7 +46,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -129,7 +133,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -209,7 +215,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -243,7 +251,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -296,7 +306,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -845,7 +857,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -857,7 +871,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -991,7 +1007,9 @@ type SunburstMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/surface_gen.go
+++ b/generated/v2.19.0/graph_objects/surface_gen.go
@@ -90,7 +90,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -150,7 +152,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -254,7 +258,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the surface color values, used for setting a color scale independent of `z`.
-	Surfacecolor interface{} `json:"surfacecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Surfacecolor *types.DataArrayType `json:"surfacecolor,omitempty"`
 
 	// Surfacecolorsrc
 	// arrayOK: false
@@ -297,7 +303,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -322,7 +330,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -347,7 +357,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -689,7 +701,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -701,7 +715,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/table_gen.go
+++ b/generated/v2.19.0/graph_objects/table_gen.go
@@ -37,7 +37,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the rendered order of the data columns; for example, a value `2` at position `0` means that column index `0` in the data will be rendered as the third column, as columns have an index base of zero.
-	Columnorder interface{} `json:"columnorder,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Columnorder *types.DataArrayType `json:"columnorder,omitempty"`
 
 	// Columnordersrc
 	// arrayOK: false
@@ -61,7 +63,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -101,7 +105,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -283,7 +289,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -330,7 +338,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -481,7 +491,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -528,7 +540,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Header cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/treemap_gen.go
+++ b/generated/v2.19.0/graph_objects/treemap_gen.go
@@ -46,7 +46,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -197,7 +203,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -230,7 +238,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -295,7 +305,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -834,7 +846,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -846,7 +860,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1008,7 +1024,9 @@ type TreemapMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/violin_gen.go
+++ b/generated/v2.19.0/graph_objects/violin_gen.go
@@ -49,7 +49,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -331,7 +335,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -361,7 +367,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/volume_gen.go
+++ b/generated/v2.19.0/graph_objects/volume_gen.go
@@ -89,7 +89,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -304,7 +308,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -329,7 +335,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -347,7 +355,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -767,7 +779,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -779,7 +793,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1075,7 +1091,9 @@ type VolumeSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1103,7 +1121,9 @@ type VolumeSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1131,7 +1151,9 @@ type VolumeSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.19.0/graph_objects/waterfall_gen.go
+++ b/generated/v2.19.0/graph_objects/waterfall_gen.go
@@ -62,7 +62,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -133,7 +135,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -185,7 +189,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing types of values. By default the values are considered as 'relative'. However; it is possible to use 'total' to compute the sums. Also 'absolute' could be applied to reset the computed total or to declare an initial value where needed.
-	Measure interface{} `json:"measure,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Measure *types.DataArrayType `json:"measure,omitempty"`
 
 	// Measuresrc
 	// arrayOK: false
@@ -364,7 +370,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -413,7 +421,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/bar_gen.go
+++ b/generated/v2.29.1/graph_objects/bar_gen.go
@@ -63,7 +63,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -139,7 +141,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -362,7 +366,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -418,7 +424,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -478,13 +486,17 @@ type BarErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -573,13 +585,17 @@ type BarErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1150,7 +1166,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1162,7 +1180,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/barpolar_gen.go
+++ b/generated/v2.29.1/graph_objects/barpolar_gen.go
@@ -44,7 +44,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -110,7 +112,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -192,7 +196,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -250,7 +256,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -768,7 +776,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -780,7 +790,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/box_gen.go
+++ b/generated/v2.29.1/graph_objects/box_gen.go
@@ -52,7 +52,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -131,7 +133,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -183,7 +187,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the lower fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `lowerfence` is not provided but a sample (in `y` or `x`) is set, we compute the lower as the last sample point below 1.5 times the IQR.
-	Lowerfence interface{} `json:"lowerfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lowerfence *types.DataArrayType `json:"lowerfence,omitempty"`
 
 	// Lowerfencesrc
 	// arrayOK: false
@@ -200,7 +206,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the mean values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `mean` is not provided but a sample (in `y` or `x`) is set, we compute the mean for each box using the sample values.
-	Mean interface{} `json:"mean,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Mean *types.DataArrayType `json:"mean,omitempty"`
 
 	// Meansrc
 	// arrayOK: false
@@ -212,7 +220,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the median values. There should be as many items as the number of boxes desired.
-	Median interface{} `json:"median,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Median *types.DataArrayType `json:"median,omitempty"`
 
 	// Mediansrc
 	// arrayOK: false
@@ -248,7 +258,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the notch span from the boxes' `median` values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `notchspan` is not provided but a sample (in `y` or `x`) is set, we compute it as 1.57 * IQR / sqrt(N), where N is the sample size.
-	Notchspan interface{} `json:"notchspan,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Notchspan *types.DataArrayType `json:"notchspan,omitempty"`
 
 	// Notchspansrc
 	// arrayOK: false
@@ -291,7 +303,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 1 values. There should be as many items as the number of boxes desired.
-	Q1 interface{} `json:"q1,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q1 *types.DataArrayType `json:"q1,omitempty"`
 
 	// Q1src
 	// arrayOK: false
@@ -303,7 +317,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 3 values. There should be as many items as the number of boxes desired.
-	Q3 interface{} `json:"q3,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q3 *types.DataArrayType `json:"q3,omitempty"`
 
 	// Q3src
 	// arrayOK: false
@@ -322,7 +338,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the standard deviation values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `sd` is not provided but a sample (in `y` or `x`) is set, we compute the standard deviation for each box using the sample values.
-	Sd interface{} `json:"sd,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Sd *types.DataArrayType `json:"sd,omitempty"`
 
 	// Sdmultiple
 	// arrayOK: false
@@ -409,7 +427,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the upper fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `upperfence` is not provided but a sample (in `y` or `x`) is set, we compute the upper as the last sample point above 1.5 times the IQR.
-	Upperfence interface{} `json:"upperfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Upperfence *types.DataArrayType `json:"upperfence,omitempty"`
 
 	// Upperfencesrc
 	// arrayOK: false
@@ -440,7 +460,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -496,7 +518,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/candlestick_gen.go
+++ b/generated/v2.29.1/graph_objects/candlestick_gen.go
@@ -32,7 +32,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/carpet_gen.go
+++ b/generated/v2.29.1/graph_objects/carpet_gen.go
@@ -32,7 +32,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing values of the first parameter value
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -55,7 +57,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -96,7 +100,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -125,7 +131,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -208,7 +216,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of x coordinates at each carpet point. If omitted, the plot is a cheater plot and the xaxis is hidden by default.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -226,7 +236,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -373,7 +385,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -662,7 +676,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -674,7 +690,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -827,7 +845,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -1116,7 +1136,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1128,7 +1150,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/choropleth_gen.go
+++ b/generated/v2.29.1/graph_objects/choropleth_gen.go
@@ -55,7 +55,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +179,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -285,7 +291,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -638,7 +646,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -650,7 +660,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/choroplethmapbox_gen.go
+++ b/generated/v2.29.1/graph_objects/choroplethmapbox_gen.go
@@ -61,7 +61,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -168,7 +172,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets which features found in *geojson* to plot using their feature `id` field.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -637,7 +645,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -649,7 +659,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/cone_gen.go
+++ b/generated/v2.29.1/graph_objects/cone_gen.go
@@ -86,7 +86,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -299,7 +305,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -324,7 +332,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -342,7 +352,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field and of the displayed cones.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -360,7 +372,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field and of the displayed cones.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -378,7 +392,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field and of the displayed cones.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -713,7 +729,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -725,7 +743,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/contour_gen.go
+++ b/generated/v2.29.1/graph_objects/contour_gen.go
@@ -72,7 +72,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -138,7 +140,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -150,7 +154,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -249,7 +255,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +310,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -428,7 +440,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -787,7 +801,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -799,7 +815,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/contourcarpet_gen.go
+++ b/generated/v2.29.1/graph_objects/contourcarpet_gen.go
@@ -32,7 +32,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -69,7 +71,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +158,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -164,7 +172,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -263,7 +273,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -312,7 +324,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -665,7 +679,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -677,7 +693,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/densitymapbox_gen.go
+++ b/generated/v2.29.1/graph_objects/densitymapbox_gen.go
@@ -61,7 +61,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -127,7 +131,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -168,7 +174,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -281,7 +289,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the points' weight. For example, a value of 10 would be equivalent to having 10 points of weight 1 in the same spot
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -634,7 +644,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -646,7 +658,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/funnel_gen.go
+++ b/generated/v2.29.1/graph_objects/funnel_gen.go
@@ -56,7 +56,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -122,7 +124,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -330,7 +334,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -379,7 +385,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -963,7 +971,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -975,7 +985,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/funnelarea_gen.go
+++ b/generated/v2.29.1/graph_objects/funnelarea_gen.go
@@ -44,7 +44,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -109,7 +111,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -132,7 +136,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -219,7 +225,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -290,7 +298,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -622,7 +632,9 @@ type FunnelareaMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/heatmap_gen.go
+++ b/generated/v2.29.1/graph_objects/heatmap_gen.go
@@ -61,7 +61,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -121,7 +123,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -133,7 +137,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -221,7 +227,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -274,7 +282,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -343,7 +353,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -412,7 +424,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -778,7 +792,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -790,7 +806,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/heatmapgl_gen.go
+++ b/generated/v2.29.1/graph_objects/heatmapgl_gen.go
@@ -55,7 +55,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -97,7 +99,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -173,7 +177,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -246,7 +254,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -277,7 +287,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -637,7 +649,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -649,7 +663,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/histogram2d_gen.go
+++ b/generated/v2.29.1/graph_objects/histogram2d_gen.go
@@ -73,7 +73,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -129,7 +131,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -317,7 +323,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -365,7 +373,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -731,7 +741,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -743,7 +755,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -957,7 +971,9 @@ type Histogram2dMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/histogram2dcontour_gen.go
+++ b/generated/v2.29.1/graph_objects/histogram2dcontour_gen.go
@@ -84,7 +84,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -291,7 +295,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -333,7 +339,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -375,7 +383,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -734,7 +744,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -746,7 +758,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1082,7 +1096,9 @@ type Histogram2dcontourMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/histogram_gen.go
+++ b/generated/v2.29.1/graph_objects/histogram_gen.go
@@ -74,7 +74,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +154,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -351,7 +355,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -387,7 +393,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -451,13 +459,17 @@ type HistogramErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -546,13 +558,17 @@ type HistogramErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1105,7 +1121,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1117,7 +1135,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/icicle_gen.go
+++ b/generated/v2.29.1/graph_objects/icicle_gen.go
@@ -46,7 +46,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -208,7 +214,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -241,7 +249,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -306,7 +316,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -855,7 +867,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -867,7 +881,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1093,7 +1109,9 @@ type IcicleMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/image_gen.go
+++ b/generated/v2.29.1/graph_objects/image_gen.go
@@ -39,7 +39,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -93,7 +95,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -105,7 +109,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +181,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -230,7 +238,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// A 2-dimensional array in which each element is an array of 3 or 4 numbers representing a color.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zmax
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/indicator_gen.go
+++ b/generated/v2.29.1/graph_objects/indicator_gen.go
@@ -39,7 +39,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -66,7 +68,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -511,7 +515,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -523,7 +529,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/isosurface_gen.go
+++ b/generated/v2.29.1/graph_objects/isosurface_gen.go
@@ -89,7 +89,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -304,7 +308,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -329,7 +335,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -347,7 +355,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -767,7 +779,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -779,7 +793,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1089,7 +1105,9 @@ type IsosurfaceSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1117,7 +1135,9 @@ type IsosurfaceSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1145,7 +1165,9 @@ type IsosurfaceSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/layout_gen.go
+++ b/generated/v2.29.1/graph_objects/layout_gen.go
@@ -223,7 +223,9 @@ type Layout struct {
 	// arrayOK: false
 	// type: data_array
 	// hiddenlabels is the funnelarea & pie chart analog of visible:'legendonly' but it can contain many labels, and can simultaneously hide slices from several pies/funnelarea charts
-	Hiddenlabels interface{} `json:"hiddenlabels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hiddenlabels *types.DataArrayType `json:"hiddenlabels,omitempty"`
 
 	// Hiddenlabelssrc
 	// arrayOK: false
@@ -1243,7 +1245,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1255,7 +1259,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -2448,7 +2454,9 @@ type LayerLine struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the length of dashes and gaps (mapbox.layer.paint.line-dasharray). Has an effect only when `type` is set to *line*.
-	Dash interface{} `json:"dash,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Dash *types.DataArrayType `json:"dash,omitempty"`
 
 	// Dashsrc
 	// arrayOK: false
@@ -3133,7 +3141,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3375,7 +3385,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3387,7 +3399,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -3627,7 +3641,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3875,7 +3891,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3887,7 +3905,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -4528,7 +4548,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -4793,7 +4815,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -4805,7 +4829,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5028,7 +5054,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5293,7 +5321,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5305,7 +5335,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5528,7 +5560,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5793,7 +5827,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5805,7 +5841,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6848,7 +6886,9 @@ type LayoutSmithImaginaryaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Defaults to `realaxis.tickvals` plus the same as negatives and zero.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7040,7 +7080,9 @@ type LayoutSmithRealaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7389,7 +7431,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7401,7 +7445,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7730,7 +7776,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7742,7 +7790,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8071,7 +8121,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -8083,7 +8135,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8661,7 +8715,9 @@ type LayoutXaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9083,7 +9139,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -9507,7 +9565,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9519,7 +9579,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9691,7 +9753,9 @@ type LayoutYaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9911,7 +9975,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -10331,7 +10397,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -10343,7 +10411,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/mesh3d_gen.go
+++ b/generated/v2.29.1/graph_objects/mesh3d_gen.go
@@ -96,7 +96,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each face Overrides *color* and *vertexcolor*.
-	Facecolor interface{} `json:"facecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Facecolor *types.DataArrayType `json:"facecolor,omitempty"`
 
 	// Facecolorsrc
 	// arrayOK: false
@@ -175,13 +179,17 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *first* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `i[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `i` represents a point in space, which is the first vertex of a triangle.
-	I interface{} `json:"i,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	I *types.DataArrayType `json:"i,omitempty"`
 
 	// Ids
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -193,7 +201,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the intensity values for vertices or cells as defined by `intensitymode`. It can be used for plotting fields on meshes.
-	Intensity interface{} `json:"intensity,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Intensity *types.DataArrayType `json:"intensity,omitempty"`
 
 	// Intensitymode
 	// arrayOK: false
@@ -218,7 +228,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *second* vertex of a triangle. For example, `{i[m], j[m], k[m]}`  together represent face m (triangle m) in the mesh, where `j[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `j` represents a point in space, which is the second vertex of a triangle.
-	J interface{} `json:"j,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	J *types.DataArrayType `json:"j,omitempty"`
 
 	// Jsrc
 	// arrayOK: false
@@ -230,7 +242,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *third* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `k[m] = n` points to the triplet  `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `k` represents a point in space, which is the third vertex of a triangle.
-	K interface{} `json:"k,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	K *types.DataArrayType `json:"k,omitempty"`
 
 	// Ksrc
 	// arrayOK: false
@@ -358,7 +372,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each vertex Overrides *color*. While Red, green and blue colors are in the range of 0 and 255; in the case of having vertex color data in RGBA format, the alpha color should be normalized to be between 0 and 1.
-	Vertexcolor interface{} `json:"vertexcolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Vertexcolor *types.DataArrayType `json:"vertexcolor,omitempty"`
 
 	// Vertexcolorsrc
 	// arrayOK: false
@@ -377,7 +393,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -402,7 +420,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -427,7 +447,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -769,7 +791,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -781,7 +805,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/ohlc_gen.go
+++ b/generated/v2.29.1/graph_objects/ohlc_gen.go
@@ -32,7 +32,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/parcats_gen.go
+++ b/generated/v2.29.1/graph_objects/parcats_gen.go
@@ -171,7 +171,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories in this dimension appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -202,7 +204,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets alternative tick labels for the categories in this dimension. Only has an effect if `categoryorder` is set to *array*. Should be an array the same length as `categoryarray` Used with `categoryorder`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -214,7 +218,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the category value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated).
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -636,7 +642,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -648,7 +656,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/parcoords_gen.go
+++ b/generated/v2.29.1/graph_objects/parcoords_gen.go
@@ -32,7 +32,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -54,7 +56,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -220,7 +224,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -232,7 +238,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -244,7 +252,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated). Each value must be a finite number.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -666,7 +676,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -678,7 +690,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/pie_gen.go
+++ b/generated/v2.29.1/graph_objects/pie_gen.go
@@ -38,7 +38,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -146,7 +150,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -262,7 +268,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -333,7 +341,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -665,7 +675,9 @@ type PieMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/pointcloud_gen.go
+++ b/generated/v2.29.1/graph_objects/pointcloud_gen.go
@@ -32,7 +32,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -62,7 +64,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -74,7 +78,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// A sequential value, 0..n, supply it to avoid creating this array inside plotting. If specified, it must be a typed `Int32Array` array. Its length must be equal to or greater than the number of points. For the best performance and memory use, create one large `indices` typed array that is guaranteed to be at least as long as the largest number of points during use, and reuse it on each `Plotly.restyle()` call.
-	Indices interface{} `json:"indices,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Indices *types.DataArrayType `json:"indices,omitempty"`
 
 	// Indicessrc
 	// arrayOK: false
@@ -186,7 +192,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -198,7 +206,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `xbounds` in the shape of `[xMin, xMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `ybounds` for the performance benefits.
-	Xbounds interface{} `json:"xbounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xbounds *types.DataArrayType `json:"xbounds,omitempty"`
 
 	// Xboundssrc
 	// arrayOK: false
@@ -216,7 +226,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Faster alternative to specifying `x` and `y` separately. If supplied, it must be a typed `Float32Array` array that represents points such that `xy[i * 2] = x[i]` and `xy[i * 2 + 1] = y[i]`
-	Xy interface{} `json:"xy,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xy *types.DataArrayType `json:"xy,omitempty"`
 
 	// Xysrc
 	// arrayOK: false
@@ -228,7 +240,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -240,7 +254,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `ybounds` in the shape of `[yMin, yMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `xbounds` for the performance benefits.
-	Ybounds interface{} `json:"ybounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ybounds *types.DataArrayType `json:"ybounds,omitempty"`
 
 	// Yboundssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/sankey_gen.go
+++ b/generated/v2.29.1/graph_objects/sankey_gen.go
@@ -39,7 +39,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -68,7 +70,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -541,7 +545,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each link.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -589,7 +595,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the link.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -606,7 +614,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the source node.
-	Source interface{} `json:"source,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Source *types.DataArrayType `json:"source,omitempty"`
 
 	// Sourcesrc
 	// arrayOK: false
@@ -618,7 +628,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the target node.
-	Target interface{} `json:"target,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Target *types.DataArrayType `json:"target,omitempty"`
 
 	// Targetsrc
 	// arrayOK: false
@@ -630,7 +642,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// A numeric value representing the flow volume value.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuesrc
 	// arrayOK: false
@@ -791,7 +805,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each node.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -833,7 +849,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the node.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -862,7 +880,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized horizontal position of the node.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -874,7 +894,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized vertical position of the node.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scatter3d_gen.go
+++ b/generated/v2.29.1/graph_objects/scatter3d_gen.go
@@ -38,7 +38,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -107,7 +109,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -290,7 +294,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -315,7 +321,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -340,7 +348,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -369,13 +379,17 @@ type Scatter3dErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -464,13 +478,17 @@ type Scatter3dErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -559,13 +577,17 @@ type Scatter3dErrorZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1096,7 +1118,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1108,7 +1132,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1588,7 +1614,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1600,7 +1628,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scatter_gen.go
+++ b/generated/v2.29.1/graph_objects/scatter_gen.go
@@ -50,7 +50,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -158,7 +160,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -359,7 +363,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -415,7 +421,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -475,13 +483,17 @@ type ScatterErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -570,13 +582,17 @@ type ScatterErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1238,7 +1254,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1250,7 +1268,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scattercarpet_gen.go
+++ b/generated/v2.29.1/graph_objects/scattercarpet_gen.go
@@ -32,7 +32,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the a-axis coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the b-axis coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -68,7 +72,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -142,7 +148,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -828,7 +836,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -840,7 +850,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scattergeo_gen.go
+++ b/generated/v2.29.1/graph_objects/scattergeo_gen.go
@@ -38,7 +38,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -123,7 +125,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -135,7 +139,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -188,7 +194,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. Coordinates correspond to the centroid of each location given. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -200,7 +208,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -815,7 +825,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -827,7 +839,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scattergl_gen.go
+++ b/generated/v2.29.1/graph_objects/scattergl_gen.go
@@ -38,7 +38,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -302,7 +306,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -358,7 +364,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -418,13 +426,17 @@ type ScatterglErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -513,13 +525,17 @@ type ScatterglErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1080,7 +1096,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1092,7 +1110,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scattermapbox_gen.go
+++ b/generated/v2.29.1/graph_objects/scattermapbox_gen.go
@@ -49,7 +49,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -128,7 +132,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -174,7 +180,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -847,7 +855,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -859,7 +869,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scatterpolar_gen.go
+++ b/generated/v2.29.1/graph_objects/scatterpolar_gen.go
@@ -44,7 +44,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -130,7 +132,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -212,7 +216,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -300,7 +306,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -853,7 +861,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -865,7 +875,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scatterpolargl_gen.go
+++ b/generated/v2.29.1/graph_objects/scatterpolargl_gen.go
@@ -38,7 +38,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -117,7 +119,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -199,7 +203,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -287,7 +293,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -816,7 +824,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -828,7 +838,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scattersmith_gen.go
+++ b/generated/v2.29.1/graph_objects/scattersmith_gen.go
@@ -44,7 +44,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -118,7 +120,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -130,7 +134,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Imag interface{} `json:"imag,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Imag *types.DataArrayType `json:"imag,omitempty"`
 
 	// Imagsrc
 	// arrayOK: false
@@ -212,7 +218,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Real interface{} `json:"real,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Real *types.DataArrayType `json:"real,omitempty"`
 
 	// Realsrc
 	// arrayOK: false
@@ -822,7 +830,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -834,7 +844,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/scatterternary_gen.go
+++ b/generated/v2.29.1/graph_objects/scatterternary_gen.go
@@ -32,7 +32,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -56,7 +60,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	C interface{} `json:"c,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	C *types.DataArrayType `json:"c,omitempty"`
 
 	// Cliponaxis
 	// arrayOK: false
@@ -80,7 +86,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -840,7 +850,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -852,7 +864,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/splom_gen.go
+++ b/generated/v2.29.1/graph_objects/splom_gen.go
@@ -32,7 +32,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -96,7 +98,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -319,7 +323,9 @@ type SplomDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the dimension values to be plotted.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -789,7 +795,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -801,7 +809,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/streamtube_gen.go
+++ b/generated/v2.29.1/graph_objects/streamtube_gen.go
@@ -79,7 +79,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -254,7 +258,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -309,7 +317,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -327,7 +337,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -345,7 +357,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -363,7 +377,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -698,7 +714,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -710,7 +728,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -992,7 +1012,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the starting position of the streamtubes
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -1004,7 +1026,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the starting position of the streamtubes
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false
@@ -1016,7 +1040,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the starting position of the streamtubes
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zsrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/sunburst_gen.go
+++ b/generated/v2.29.1/graph_objects/sunburst_gen.go
@@ -46,7 +46,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -129,7 +133,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -249,7 +257,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +312,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -851,7 +863,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -863,7 +877,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1089,7 +1105,9 @@ type SunburstMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/surface_gen.go
+++ b/generated/v2.29.1/graph_objects/surface_gen.go
@@ -90,7 +90,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -150,7 +152,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -260,7 +264,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the surface color values, used for setting a color scale independent of `z`.
-	Surfacecolor interface{} `json:"surfacecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Surfacecolor *types.DataArrayType `json:"surfacecolor,omitempty"`
 
 	// Surfacecolorsrc
 	// arrayOK: false
@@ -303,7 +309,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -328,7 +336,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -353,7 +363,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -695,7 +707,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -707,7 +721,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/table_gen.go
+++ b/generated/v2.29.1/graph_objects/table_gen.go
@@ -37,7 +37,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the rendered order of the data columns; for example, a value `2` at position `0` means that column index `0` in the data will be rendered as the third column, as columns have an index base of zero.
-	Columnorder interface{} `json:"columnorder,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Columnorder *types.DataArrayType `json:"columnorder,omitempty"`
 
 	// Columnordersrc
 	// arrayOK: false
@@ -61,7 +63,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -101,7 +105,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -289,7 +295,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -336,7 +344,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -487,7 +497,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -534,7 +546,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Header cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/treemap_gen.go
+++ b/generated/v2.29.1/graph_objects/treemap_gen.go
@@ -46,7 +46,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -203,7 +209,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -236,7 +244,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -301,7 +311,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -840,7 +852,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -852,7 +866,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1106,7 +1122,9 @@ type TreemapMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/violin_gen.go
+++ b/generated/v2.29.1/graph_objects/violin_gen.go
@@ -49,7 +49,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -337,7 +341,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -367,7 +373,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/volume_gen.go
+++ b/generated/v2.29.1/graph_objects/volume_gen.go
@@ -89,7 +89,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -310,7 +314,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -335,7 +341,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -353,7 +361,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -371,7 +381,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -773,7 +785,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -785,7 +799,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1095,7 +1111,9 @@ type VolumeSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1123,7 +1141,9 @@ type VolumeSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1151,7 +1171,9 @@ type VolumeSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.29.1/graph_objects/waterfall_gen.go
+++ b/generated/v2.29.1/graph_objects/waterfall_gen.go
@@ -62,7 +62,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -133,7 +135,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -191,7 +195,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing types of values. By default the values are considered as 'relative'. However; it is possible to use 'total' to compute the sums. Also 'absolute' could be applied to reset the computed total or to declare an initial value where needed.
-	Measure interface{} `json:"measure,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Measure *types.DataArrayType `json:"measure,omitempty"`
 
 	// Measuresrc
 	// arrayOK: false
@@ -370,7 +376,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -419,7 +427,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/bar_gen.go
+++ b/generated/v2.31.1/graph_objects/bar_gen.go
@@ -63,7 +63,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -139,7 +141,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -362,7 +366,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -418,7 +424,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -484,13 +492,17 @@ type BarErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -579,13 +591,17 @@ type BarErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1156,7 +1172,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1168,7 +1186,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/barpolar_gen.go
+++ b/generated/v2.31.1/graph_objects/barpolar_gen.go
@@ -44,7 +44,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -110,7 +112,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -192,7 +196,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -250,7 +256,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -768,7 +776,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -780,7 +790,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/box_gen.go
+++ b/generated/v2.31.1/graph_objects/box_gen.go
@@ -52,7 +52,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -131,7 +133,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -183,7 +187,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the lower fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `lowerfence` is not provided but a sample (in `y` or `x`) is set, we compute the lower as the last sample point below 1.5 times the IQR.
-	Lowerfence interface{} `json:"lowerfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lowerfence *types.DataArrayType `json:"lowerfence,omitempty"`
 
 	// Lowerfencesrc
 	// arrayOK: false
@@ -200,7 +206,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the mean values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `mean` is not provided but a sample (in `y` or `x`) is set, we compute the mean for each box using the sample values.
-	Mean interface{} `json:"mean,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Mean *types.DataArrayType `json:"mean,omitempty"`
 
 	// Meansrc
 	// arrayOK: false
@@ -212,7 +220,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the median values. There should be as many items as the number of boxes desired.
-	Median interface{} `json:"median,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Median *types.DataArrayType `json:"median,omitempty"`
 
 	// Mediansrc
 	// arrayOK: false
@@ -248,7 +258,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the notch span from the boxes' `median` values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `notchspan` is not provided but a sample (in `y` or `x`) is set, we compute it as 1.57 * IQR / sqrt(N), where N is the sample size.
-	Notchspan interface{} `json:"notchspan,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Notchspan *types.DataArrayType `json:"notchspan,omitempty"`
 
 	// Notchspansrc
 	// arrayOK: false
@@ -291,7 +303,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 1 values. There should be as many items as the number of boxes desired.
-	Q1 interface{} `json:"q1,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q1 *types.DataArrayType `json:"q1,omitempty"`
 
 	// Q1src
 	// arrayOK: false
@@ -303,7 +317,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 3 values. There should be as many items as the number of boxes desired.
-	Q3 interface{} `json:"q3,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q3 *types.DataArrayType `json:"q3,omitempty"`
 
 	// Q3src
 	// arrayOK: false
@@ -322,7 +338,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the standard deviation values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `sd` is not provided but a sample (in `y` or `x`) is set, we compute the standard deviation for each box using the sample values.
-	Sd interface{} `json:"sd,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Sd *types.DataArrayType `json:"sd,omitempty"`
 
 	// Sdmultiple
 	// arrayOK: false
@@ -409,7 +427,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the upper fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `upperfence` is not provided but a sample (in `y` or `x`) is set, we compute the upper as the last sample point above 1.5 times the IQR.
-	Upperfence interface{} `json:"upperfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Upperfence *types.DataArrayType `json:"upperfence,omitempty"`
 
 	// Upperfencesrc
 	// arrayOK: false
@@ -440,7 +460,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -496,7 +518,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/candlestick_gen.go
+++ b/generated/v2.31.1/graph_objects/candlestick_gen.go
@@ -32,7 +32,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/carpet_gen.go
+++ b/generated/v2.31.1/graph_objects/carpet_gen.go
@@ -32,7 +32,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing values of the first parameter value
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -55,7 +57,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -96,7 +100,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -125,7 +131,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -208,7 +216,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of x coordinates at each carpet point. If omitted, the plot is a cheater plot and the xaxis is hidden by default.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -226,7 +236,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -379,7 +391,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -668,7 +682,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -680,7 +696,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -833,7 +851,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -1122,7 +1142,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1134,7 +1156,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/choropleth_gen.go
+++ b/generated/v2.31.1/graph_objects/choropleth_gen.go
@@ -55,7 +55,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +179,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -285,7 +291,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -638,7 +646,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -650,7 +660,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/choroplethmapbox_gen.go
+++ b/generated/v2.31.1/graph_objects/choroplethmapbox_gen.go
@@ -61,7 +61,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -168,7 +172,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets which features found in *geojson* to plot using their feature `id` field.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -637,7 +645,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -649,7 +659,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/cone_gen.go
+++ b/generated/v2.31.1/graph_objects/cone_gen.go
@@ -86,7 +86,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -299,7 +305,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -324,7 +332,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -342,7 +352,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field and of the displayed cones.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -360,7 +372,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field and of the displayed cones.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -378,7 +392,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field and of the displayed cones.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -713,7 +729,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -725,7 +743,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/contour_gen.go
+++ b/generated/v2.31.1/graph_objects/contour_gen.go
@@ -72,7 +72,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -138,7 +140,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -150,7 +154,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -249,7 +255,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +310,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -428,7 +440,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -793,7 +807,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -805,7 +821,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/contourcarpet_gen.go
+++ b/generated/v2.31.1/graph_objects/contourcarpet_gen.go
@@ -32,7 +32,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -69,7 +71,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +158,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -164,7 +172,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -263,7 +273,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -312,7 +324,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -671,7 +685,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -683,7 +699,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/densitymapbox_gen.go
+++ b/generated/v2.31.1/graph_objects/densitymapbox_gen.go
@@ -61,7 +61,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -127,7 +131,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -168,7 +174,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -281,7 +289,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the points' weight. For example, a value of 10 would be equivalent to having 10 points of weight 1 in the same spot
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -634,7 +644,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -646,7 +658,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/funnel_gen.go
+++ b/generated/v2.31.1/graph_objects/funnel_gen.go
@@ -56,7 +56,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -122,7 +124,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -330,7 +334,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -379,7 +385,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -969,7 +977,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -981,7 +991,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/funnelarea_gen.go
+++ b/generated/v2.31.1/graph_objects/funnelarea_gen.go
@@ -44,7 +44,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -109,7 +111,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -132,7 +136,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -219,7 +225,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -290,7 +298,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -622,7 +632,9 @@ type FunnelareaMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/heatmap_gen.go
+++ b/generated/v2.31.1/graph_objects/heatmap_gen.go
@@ -61,7 +61,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -121,7 +123,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -133,7 +137,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -221,7 +227,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -274,7 +282,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -343,7 +353,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -412,7 +424,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -784,7 +798,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -796,7 +812,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/heatmapgl_gen.go
+++ b/generated/v2.31.1/graph_objects/heatmapgl_gen.go
@@ -55,7 +55,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -97,7 +99,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -173,7 +177,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -246,7 +254,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -277,7 +287,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -637,7 +649,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -649,7 +663,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/histogram2d_gen.go
+++ b/generated/v2.31.1/graph_objects/histogram2d_gen.go
@@ -73,7 +73,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -129,7 +131,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -317,7 +323,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -365,7 +373,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -731,7 +741,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -743,7 +755,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -957,7 +971,9 @@ type Histogram2dMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/histogram2dcontour_gen.go
+++ b/generated/v2.31.1/graph_objects/histogram2dcontour_gen.go
@@ -84,7 +84,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -291,7 +295,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -333,7 +339,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -375,7 +383,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -734,7 +744,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -746,7 +758,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1082,7 +1096,9 @@ type Histogram2dcontourMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/histogram_gen.go
+++ b/generated/v2.31.1/graph_objects/histogram_gen.go
@@ -74,7 +74,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +154,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -351,7 +355,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -387,7 +393,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -457,13 +465,17 @@ type HistogramErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -552,13 +564,17 @@ type HistogramErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1111,7 +1127,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1123,7 +1141,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/icicle_gen.go
+++ b/generated/v2.31.1/graph_objects/icicle_gen.go
@@ -46,7 +46,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -208,7 +214,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -241,7 +249,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -306,7 +316,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -855,7 +867,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -867,7 +881,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1093,7 +1109,9 @@ type IcicleMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/image_gen.go
+++ b/generated/v2.31.1/graph_objects/image_gen.go
@@ -39,7 +39,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -93,7 +95,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -105,7 +109,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +181,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -230,7 +238,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// A 2-dimensional array in which each element is an array of 3 or 4 numbers representing a color.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zmax
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/indicator_gen.go
+++ b/generated/v2.31.1/graph_objects/indicator_gen.go
@@ -39,7 +39,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -66,7 +68,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -511,7 +515,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -523,7 +529,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/isosurface_gen.go
+++ b/generated/v2.31.1/graph_objects/isosurface_gen.go
@@ -89,7 +89,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -304,7 +308,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -329,7 +335,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -347,7 +355,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -767,7 +779,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -779,7 +793,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1089,7 +1105,9 @@ type IsosurfaceSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1117,7 +1135,9 @@ type IsosurfaceSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1145,7 +1165,9 @@ type IsosurfaceSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/layout_gen.go
+++ b/generated/v2.31.1/graph_objects/layout_gen.go
@@ -223,7 +223,9 @@ type Layout struct {
 	// arrayOK: false
 	// type: data_array
 	// hiddenlabels is the funnelarea & pie chart analog of visible:'legendonly' but it can contain many labels, and can simultaneously hide slices from several pies/funnelarea charts
-	Hiddenlabels interface{} `json:"hiddenlabels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hiddenlabels *types.DataArrayType `json:"hiddenlabels,omitempty"`
 
 	// Hiddenlabelssrc
 	// arrayOK: false
@@ -1250,7 +1252,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1262,7 +1266,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -2461,7 +2467,9 @@ type LayerLine struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the length of dashes and gaps (mapbox.layer.paint.line-dasharray). Has an effect only when `type` is set to *line*.
-	Dash interface{} `json:"dash,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Dash *types.DataArrayType `json:"dash,omitempty"`
 
 	// Dashsrc
 	// arrayOK: false
@@ -3146,7 +3154,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3388,7 +3398,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3400,7 +3412,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -3640,7 +3654,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3888,7 +3904,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3900,7 +3918,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -4541,7 +4561,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -4806,7 +4828,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -4818,7 +4842,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5041,7 +5067,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5306,7 +5334,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5318,7 +5348,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5541,7 +5573,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5806,7 +5840,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5818,7 +5854,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6861,7 +6899,9 @@ type LayoutSmithImaginaryaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Defaults to `realaxis.tickvals` plus the same as negatives and zero.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7053,7 +7093,9 @@ type LayoutSmithRealaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7402,7 +7444,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7414,7 +7458,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7743,7 +7789,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -7755,7 +7803,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8084,7 +8134,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -8096,7 +8148,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8674,7 +8728,9 @@ type LayoutXaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9096,7 +9152,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -9520,7 +9578,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9532,7 +9592,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9704,7 +9766,9 @@ type LayoutYaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9924,7 +9988,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -10344,7 +10410,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -10356,7 +10424,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/mesh3d_gen.go
+++ b/generated/v2.31.1/graph_objects/mesh3d_gen.go
@@ -96,7 +96,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each face Overrides *color* and *vertexcolor*.
-	Facecolor interface{} `json:"facecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Facecolor *types.DataArrayType `json:"facecolor,omitempty"`
 
 	// Facecolorsrc
 	// arrayOK: false
@@ -175,13 +179,17 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *first* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `i[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `i` represents a point in space, which is the first vertex of a triangle.
-	I interface{} `json:"i,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	I *types.DataArrayType `json:"i,omitempty"`
 
 	// Ids
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -193,7 +201,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the intensity values for vertices or cells as defined by `intensitymode`. It can be used for plotting fields on meshes.
-	Intensity interface{} `json:"intensity,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Intensity *types.DataArrayType `json:"intensity,omitempty"`
 
 	// Intensitymode
 	// arrayOK: false
@@ -218,7 +228,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *second* vertex of a triangle. For example, `{i[m], j[m], k[m]}`  together represent face m (triangle m) in the mesh, where `j[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `j` represents a point in space, which is the second vertex of a triangle.
-	J interface{} `json:"j,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	J *types.DataArrayType `json:"j,omitempty"`
 
 	// Jsrc
 	// arrayOK: false
@@ -230,7 +242,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *third* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `k[m] = n` points to the triplet  `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `k` represents a point in space, which is the third vertex of a triangle.
-	K interface{} `json:"k,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	K *types.DataArrayType `json:"k,omitempty"`
 
 	// Ksrc
 	// arrayOK: false
@@ -358,7 +372,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each vertex Overrides *color*. While Red, green and blue colors are in the range of 0 and 255; in the case of having vertex color data in RGBA format, the alpha color should be normalized to be between 0 and 1.
-	Vertexcolor interface{} `json:"vertexcolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Vertexcolor *types.DataArrayType `json:"vertexcolor,omitempty"`
 
 	// Vertexcolorsrc
 	// arrayOK: false
@@ -377,7 +393,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -402,7 +420,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -427,7 +447,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -769,7 +791,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -781,7 +805,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/ohlc_gen.go
+++ b/generated/v2.31.1/graph_objects/ohlc_gen.go
@@ -32,7 +32,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/parcats_gen.go
+++ b/generated/v2.31.1/graph_objects/parcats_gen.go
@@ -171,7 +171,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories in this dimension appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -202,7 +204,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets alternative tick labels for the categories in this dimension. Only has an effect if `categoryorder` is set to *array*. Should be an array the same length as `categoryarray` Used with `categoryorder`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -214,7 +218,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the category value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated).
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -636,7 +642,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -648,7 +656,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/parcoords_gen.go
+++ b/generated/v2.31.1/graph_objects/parcoords_gen.go
@@ -32,7 +32,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -54,7 +56,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -220,7 +224,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -232,7 +238,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -244,7 +252,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated). Each value must be a finite number.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -666,7 +676,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -678,7 +690,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/pie_gen.go
+++ b/generated/v2.31.1/graph_objects/pie_gen.go
@@ -38,7 +38,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -146,7 +150,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -262,7 +268,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -333,7 +341,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -665,7 +675,9 @@ type PieMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/pointcloud_gen.go
+++ b/generated/v2.31.1/graph_objects/pointcloud_gen.go
@@ -32,7 +32,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -62,7 +64,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -74,7 +78,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// A sequential value, 0..n, supply it to avoid creating this array inside plotting. If specified, it must be a typed `Int32Array` array. Its length must be equal to or greater than the number of points. For the best performance and memory use, create one large `indices` typed array that is guaranteed to be at least as long as the largest number of points during use, and reuse it on each `Plotly.restyle()` call.
-	Indices interface{} `json:"indices,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Indices *types.DataArrayType `json:"indices,omitempty"`
 
 	// Indicessrc
 	// arrayOK: false
@@ -186,7 +192,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -198,7 +206,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `xbounds` in the shape of `[xMin, xMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `ybounds` for the performance benefits.
-	Xbounds interface{} `json:"xbounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xbounds *types.DataArrayType `json:"xbounds,omitempty"`
 
 	// Xboundssrc
 	// arrayOK: false
@@ -216,7 +226,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Faster alternative to specifying `x` and `y` separately. If supplied, it must be a typed `Float32Array` array that represents points such that `xy[i * 2] = x[i]` and `xy[i * 2 + 1] = y[i]`
-	Xy interface{} `json:"xy,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xy *types.DataArrayType `json:"xy,omitempty"`
 
 	// Xysrc
 	// arrayOK: false
@@ -228,7 +240,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -240,7 +254,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `ybounds` in the shape of `[yMin, yMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `xbounds` for the performance benefits.
-	Ybounds interface{} `json:"ybounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ybounds *types.DataArrayType `json:"ybounds,omitempty"`
 
 	// Yboundssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/sankey_gen.go
+++ b/generated/v2.31.1/graph_objects/sankey_gen.go
@@ -39,7 +39,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -68,7 +70,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -541,7 +545,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each link.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -589,7 +595,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the link.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -606,7 +614,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the source node.
-	Source interface{} `json:"source,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Source *types.DataArrayType `json:"source,omitempty"`
 
 	// Sourcesrc
 	// arrayOK: false
@@ -618,7 +628,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the target node.
-	Target interface{} `json:"target,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Target *types.DataArrayType `json:"target,omitempty"`
 
 	// Targetsrc
 	// arrayOK: false
@@ -630,7 +642,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// A numeric value representing the flow volume value.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuesrc
 	// arrayOK: false
@@ -791,7 +805,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each node.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -833,7 +849,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the node.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -862,7 +880,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized horizontal position of the node.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -874,7 +894,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized vertical position of the node.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scatter3d_gen.go
+++ b/generated/v2.31.1/graph_objects/scatter3d_gen.go
@@ -38,7 +38,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -107,7 +109,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -290,7 +294,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -315,7 +321,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -340,7 +348,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -369,13 +379,17 @@ type Scatter3dErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -464,13 +478,17 @@ type Scatter3dErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -559,13 +577,17 @@ type Scatter3dErrorZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1096,7 +1118,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1108,7 +1132,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1588,7 +1614,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1600,7 +1628,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scatter_gen.go
+++ b/generated/v2.31.1/graph_objects/scatter_gen.go
@@ -50,7 +50,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -163,7 +165,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -364,7 +368,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -420,7 +426,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -486,13 +494,17 @@ type ScatterErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -581,13 +593,17 @@ type ScatterErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1278,7 +1294,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1290,7 +1308,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scattercarpet_gen.go
+++ b/generated/v2.31.1/graph_objects/scattercarpet_gen.go
@@ -32,7 +32,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the a-axis coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the b-axis coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -68,7 +72,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -142,7 +148,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -834,7 +842,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -846,7 +856,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scattergeo_gen.go
+++ b/generated/v2.31.1/graph_objects/scattergeo_gen.go
@@ -38,7 +38,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -123,7 +125,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -135,7 +139,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -188,7 +194,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. Coordinates correspond to the centroid of each location given. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -200,7 +208,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -815,7 +825,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -827,7 +839,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scattergl_gen.go
+++ b/generated/v2.31.1/graph_objects/scattergl_gen.go
@@ -38,7 +38,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -302,7 +306,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -358,7 +364,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -418,13 +426,17 @@ type ScatterglErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -513,13 +525,17 @@ type ScatterglErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1080,7 +1096,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1092,7 +1110,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scattermapbox_gen.go
+++ b/generated/v2.31.1/graph_objects/scattermapbox_gen.go
@@ -49,7 +49,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -128,7 +132,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -174,7 +180,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -847,7 +855,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -859,7 +869,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scatterpolar_gen.go
+++ b/generated/v2.31.1/graph_objects/scatterpolar_gen.go
@@ -44,7 +44,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -130,7 +132,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -212,7 +216,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -300,7 +306,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -853,7 +861,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -865,7 +875,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scatterpolargl_gen.go
+++ b/generated/v2.31.1/graph_objects/scatterpolargl_gen.go
@@ -38,7 +38,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -117,7 +119,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -199,7 +203,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -287,7 +293,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -816,7 +824,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -828,7 +838,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scattersmith_gen.go
+++ b/generated/v2.31.1/graph_objects/scattersmith_gen.go
@@ -44,7 +44,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -118,7 +120,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -130,7 +134,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Imag interface{} `json:"imag,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Imag *types.DataArrayType `json:"imag,omitempty"`
 
 	// Imagsrc
 	// arrayOK: false
@@ -212,7 +218,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Real interface{} `json:"real,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Real *types.DataArrayType `json:"real,omitempty"`
 
 	// Realsrc
 	// arrayOK: false
@@ -822,7 +830,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -834,7 +844,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/scatterternary_gen.go
+++ b/generated/v2.31.1/graph_objects/scatterternary_gen.go
@@ -32,7 +32,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -56,7 +60,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	C interface{} `json:"c,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	C *types.DataArrayType `json:"c,omitempty"`
 
 	// Cliponaxis
 	// arrayOK: false
@@ -80,7 +86,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -840,7 +850,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -852,7 +864,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/splom_gen.go
+++ b/generated/v2.31.1/graph_objects/splom_gen.go
@@ -32,7 +32,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -96,7 +98,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -319,7 +323,9 @@ type SplomDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the dimension values to be plotted.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -789,7 +795,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -801,7 +809,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/streamtube_gen.go
+++ b/generated/v2.31.1/graph_objects/streamtube_gen.go
@@ -79,7 +79,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -254,7 +258,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -309,7 +317,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -327,7 +337,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -345,7 +357,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -363,7 +377,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -698,7 +714,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -710,7 +728,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -992,7 +1012,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the starting position of the streamtubes
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -1004,7 +1026,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the starting position of the streamtubes
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false
@@ -1016,7 +1040,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the starting position of the streamtubes
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zsrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/sunburst_gen.go
+++ b/generated/v2.31.1/graph_objects/sunburst_gen.go
@@ -46,7 +46,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -129,7 +133,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -249,7 +257,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +312,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -851,7 +863,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -863,7 +877,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1089,7 +1105,9 @@ type SunburstMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/surface_gen.go
+++ b/generated/v2.31.1/graph_objects/surface_gen.go
@@ -90,7 +90,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -150,7 +152,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -260,7 +264,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the surface color values, used for setting a color scale independent of `z`.
-	Surfacecolor interface{} `json:"surfacecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Surfacecolor *types.DataArrayType `json:"surfacecolor,omitempty"`
 
 	// Surfacecolorsrc
 	// arrayOK: false
@@ -303,7 +309,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -328,7 +336,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -353,7 +363,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -695,7 +707,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -707,7 +721,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/table_gen.go
+++ b/generated/v2.31.1/graph_objects/table_gen.go
@@ -37,7 +37,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the rendered order of the data columns; for example, a value `2` at position `0` means that column index `0` in the data will be rendered as the third column, as columns have an index base of zero.
-	Columnorder interface{} `json:"columnorder,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Columnorder *types.DataArrayType `json:"columnorder,omitempty"`
 
 	// Columnordersrc
 	// arrayOK: false
@@ -61,7 +63,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -101,7 +105,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -289,7 +295,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -336,7 +344,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -487,7 +497,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -534,7 +546,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Header cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/treemap_gen.go
+++ b/generated/v2.31.1/graph_objects/treemap_gen.go
@@ -46,7 +46,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -203,7 +209,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -236,7 +244,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -301,7 +311,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -840,7 +852,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -852,7 +866,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1106,7 +1122,9 @@ type TreemapMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/violin_gen.go
+++ b/generated/v2.31.1/graph_objects/violin_gen.go
@@ -49,7 +49,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -337,7 +341,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -367,7 +373,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/volume_gen.go
+++ b/generated/v2.31.1/graph_objects/volume_gen.go
@@ -89,7 +89,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -310,7 +314,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -335,7 +341,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -353,7 +361,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -371,7 +381,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -773,7 +785,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -785,7 +799,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1095,7 +1111,9 @@ type VolumeSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1123,7 +1141,9 @@ type VolumeSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1151,7 +1171,9 @@ type VolumeSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.31.1/graph_objects/waterfall_gen.go
+++ b/generated/v2.31.1/graph_objects/waterfall_gen.go
@@ -62,7 +62,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -133,7 +135,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -191,7 +195,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing types of values. By default the values are considered as 'relative'. However; it is possible to use 'total' to compute the sums. Also 'absolute' could be applied to reset the computed total or to declare an initial value where needed.
-	Measure interface{} `json:"measure,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Measure *types.DataArrayType `json:"measure,omitempty"`
 
 	// Measuresrc
 	// arrayOK: false
@@ -370,7 +376,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -419,7 +427,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/bar_gen.go
+++ b/generated/v2.34.0/graph_objects/bar_gen.go
@@ -63,7 +63,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -139,7 +141,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -362,7 +366,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -418,7 +424,9 @@ type Bar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -484,13 +492,17 @@ type BarErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -579,13 +591,17 @@ type BarErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1428,7 +1444,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1440,7 +1458,9 @@ type BarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/barpolar_gen.go
+++ b/generated/v2.34.0/graph_objects/barpolar_gen.go
@@ -44,7 +44,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -110,7 +112,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -192,7 +196,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -250,7 +256,9 @@ type Barpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -964,7 +972,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -976,7 +986,9 @@ type BarpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/box_gen.go
+++ b/generated/v2.34.0/graph_objects/box_gen.go
@@ -52,7 +52,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -131,7 +133,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -183,7 +187,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the lower fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `lowerfence` is not provided but a sample (in `y` or `x`) is set, we compute the lower as the last sample point below 1.5 times the IQR.
-	Lowerfence interface{} `json:"lowerfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lowerfence *types.DataArrayType `json:"lowerfence,omitempty"`
 
 	// Lowerfencesrc
 	// arrayOK: false
@@ -200,7 +206,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the mean values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `mean` is not provided but a sample (in `y` or `x`) is set, we compute the mean for each box using the sample values.
-	Mean interface{} `json:"mean,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Mean *types.DataArrayType `json:"mean,omitempty"`
 
 	// Meansrc
 	// arrayOK: false
@@ -212,7 +220,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the median values. There should be as many items as the number of boxes desired.
-	Median interface{} `json:"median,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Median *types.DataArrayType `json:"median,omitempty"`
 
 	// Mediansrc
 	// arrayOK: false
@@ -248,7 +258,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the notch span from the boxes' `median` values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `notchspan` is not provided but a sample (in `y` or `x`) is set, we compute it as 1.57 * IQR / sqrt(N), where N is the sample size.
-	Notchspan interface{} `json:"notchspan,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Notchspan *types.DataArrayType `json:"notchspan,omitempty"`
 
 	// Notchspansrc
 	// arrayOK: false
@@ -291,7 +303,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 1 values. There should be as many items as the number of boxes desired.
-	Q1 interface{} `json:"q1,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q1 *types.DataArrayType `json:"q1,omitempty"`
 
 	// Q1src
 	// arrayOK: false
@@ -303,7 +317,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Quartile 3 values. There should be as many items as the number of boxes desired.
-	Q3 interface{} `json:"q3,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Q3 *types.DataArrayType `json:"q3,omitempty"`
 
 	// Q3src
 	// arrayOK: false
@@ -322,7 +338,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the standard deviation values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `sd` is not provided but a sample (in `y` or `x`) is set, we compute the standard deviation for each box using the sample values.
-	Sd interface{} `json:"sd,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Sd *types.DataArrayType `json:"sd,omitempty"`
 
 	// Sdmultiple
 	// arrayOK: false
@@ -409,7 +427,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the upper fence values. There should be as many items as the number of boxes desired. This attribute has effect only under the q1/median/q3 signature. If `upperfence` is not provided but a sample (in `y` or `x`) is set, we compute the upper as the last sample point above 1.5 times the IQR.
-	Upperfence interface{} `json:"upperfence,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Upperfence *types.DataArrayType `json:"upperfence,omitempty"`
 
 	// Upperfencesrc
 	// arrayOK: false
@@ -440,7 +460,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -496,7 +518,9 @@ type Box struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/candlestick_gen.go
+++ b/generated/v2.34.0/graph_objects/candlestick_gen.go
@@ -32,7 +32,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Candlestick struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/carpet_gen.go
+++ b/generated/v2.34.0/graph_objects/carpet_gen.go
@@ -32,7 +32,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing values of the first parameter value
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -55,7 +57,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -96,7 +100,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -125,7 +131,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -208,7 +216,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of x coordinates at each carpet point. If omitted, the plot is a cheater plot and the xaxis is hidden by default.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -226,7 +236,9 @@ type Carpet struct {
 	// arrayOK: false
 	// type: data_array
 	// A two dimensional array of y coordinates at each carpet point.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -459,7 +471,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -748,7 +762,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -760,7 +776,9 @@ type CarpetAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -993,7 +1011,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -1282,7 +1302,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1294,7 +1316,9 @@ type CarpetBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/choropleth_gen.go
+++ b/generated/v2.34.0/graph_objects/choropleth_gen.go
@@ -55,7 +55,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +179,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -285,7 +291,9 @@ type Choropleth struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -718,7 +726,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -730,7 +740,9 @@ type ChoroplethColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/choroplethmapbox_gen.go
+++ b/generated/v2.34.0/graph_objects/choroplethmapbox_gen.go
@@ -61,7 +61,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -168,7 +172,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets which features found in *geojson* to plot using their feature `id` field.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Choroplethmapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color values.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -717,7 +725,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -729,7 +739,9 @@ type ChoroplethmapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/cone_gen.go
+++ b/generated/v2.34.0/graph_objects/cone_gen.go
@@ -86,7 +86,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -299,7 +305,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -324,7 +332,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -342,7 +352,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field and of the displayed cones.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -360,7 +372,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field and of the displayed cones.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -378,7 +392,9 @@ type Cone struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field and of the displayed cones.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -793,7 +809,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -805,7 +823,9 @@ type ConeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/contour_gen.go
+++ b/generated/v2.34.0/graph_objects/contour_gen.go
@@ -72,7 +72,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -138,7 +140,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -150,7 +154,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -249,7 +255,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +310,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -428,7 +440,9 @@ type Contour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -873,7 +887,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -885,7 +901,9 @@ type ContourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/contourcarpet_gen.go
+++ b/generated/v2.34.0/graph_objects/contourcarpet_gen.go
@@ -32,7 +32,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// A0
 	// arrayOK: false
@@ -69,7 +71,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// B0
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +158,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -164,7 +172,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -263,7 +273,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -312,7 +324,9 @@ type Contourcarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -751,7 +765,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -763,7 +779,9 @@ type ContourcarpetColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/densitymapbox_gen.go
+++ b/generated/v2.34.0/graph_objects/densitymapbox_gen.go
@@ -61,7 +61,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -127,7 +131,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -168,7 +174,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -281,7 +289,9 @@ type Densitymapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the points' weight. For example, a value of 10 would be equivalent to having 10 points of weight 1 in the same spot
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -714,7 +724,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -726,7 +738,9 @@ type DensitymapboxColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/funnel_gen.go
+++ b/generated/v2.34.0/graph_objects/funnel_gen.go
@@ -56,7 +56,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -122,7 +124,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -330,7 +334,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -379,7 +385,9 @@ type Funnel struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -1241,7 +1249,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1253,7 +1263,9 @@ type FunnelMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/funnelarea_gen.go
+++ b/generated/v2.34.0/graph_objects/funnelarea_gen.go
@@ -44,7 +44,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -109,7 +111,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -132,7 +136,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -219,7 +225,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -290,7 +298,9 @@ type Funnelarea struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -814,7 +824,9 @@ type FunnelareaMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/heatmap_gen.go
+++ b/generated/v2.34.0/graph_objects/heatmap_gen.go
@@ -61,7 +61,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -121,7 +123,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -133,7 +137,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -221,7 +227,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -274,7 +282,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -343,7 +353,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -412,7 +424,9 @@ type Heatmap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -864,7 +878,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -876,7 +892,9 @@ type HeatmapColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/heatmapgl_gen.go
+++ b/generated/v2.34.0/graph_objects/heatmapgl_gen.go
@@ -55,7 +55,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -97,7 +99,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -173,7 +177,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -246,7 +254,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -277,7 +287,9 @@ type Heatmapgl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -717,7 +729,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -729,7 +743,9 @@ type HeatmapglColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/histogram2d_gen.go
+++ b/generated/v2.34.0/graph_objects/histogram2d_gen.go
@@ -73,7 +73,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -129,7 +131,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -269,7 +273,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -317,7 +323,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -365,7 +373,9 @@ type Histogram2d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -811,7 +821,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -823,7 +835,9 @@ type Histogram2dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1153,7 +1167,9 @@ type Histogram2dMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/histogram2dcontour_gen.go
+++ b/generated/v2.34.0/graph_objects/histogram2dcontour_gen.go
@@ -84,7 +84,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -140,7 +142,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -291,7 +295,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -333,7 +339,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -375,7 +383,9 @@ type Histogram2dcontour struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zauto
 	// arrayOK: false
@@ -814,7 +824,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -826,7 +838,9 @@ type Histogram2dcontourColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1318,7 +1332,9 @@ type Histogram2dcontourMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the aggregation data.
-	Color interface{} `json:"color,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Color *types.DataArrayType `json:"color,omitempty"`
 
 	// Colorsrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/histogram_gen.go
+++ b/generated/v2.34.0/graph_objects/histogram_gen.go
@@ -74,7 +74,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -152,7 +154,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -351,7 +355,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the x axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -387,7 +393,9 @@ type Histogram struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sample data to be binned on the y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -457,13 +465,17 @@ type HistogramErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -552,13 +564,17 @@ type HistogramErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1347,7 +1363,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1359,7 +1377,9 @@ type HistogramMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/icicle_gen.go
+++ b/generated/v2.34.0/graph_objects/icicle_gen.go
@@ -46,7 +46,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -208,7 +214,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -241,7 +249,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -306,7 +316,9 @@ type Icicle struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -1127,7 +1139,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1139,7 +1153,9 @@ type IcicleMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1365,7 +1381,9 @@ type IcicleMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/image_gen.go
+++ b/generated/v2.34.0/graph_objects/image_gen.go
@@ -39,7 +39,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -93,7 +95,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Same as `text`.
-	Hovertext interface{} `json:"hovertext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hovertext *types.DataArrayType `json:"hovertext,omitempty"`
 
 	// Hovertextsrc
 	// arrayOK: false
@@ -105,7 +109,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -175,7 +181,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text elements associated with each z value.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textsrc
 	// arrayOK: false
@@ -230,7 +238,9 @@ type Image struct {
 	// arrayOK: false
 	// type: data_array
 	// A 2-dimensional array in which each element is an array of 3 or 4 numbers representing a color.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zmax
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/indicator_gen.go
+++ b/generated/v2.34.0/graph_objects/indicator_gen.go
@@ -39,7 +39,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -66,7 +68,9 @@ type Indicator struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -591,7 +595,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -603,7 +609,9 @@ type IndicatorGaugeAxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/isosurface_gen.go
+++ b/generated/v2.34.0/graph_objects/isosurface_gen.go
@@ -89,7 +89,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -304,7 +308,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -329,7 +335,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -347,7 +355,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -365,7 +375,9 @@ type Isosurface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -847,7 +859,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -859,7 +873,9 @@ type IsosurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1285,7 +1301,9 @@ type IsosurfaceSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1313,7 +1331,9 @@ type IsosurfaceSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1341,7 +1361,9 @@ type IsosurfaceSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/layout_gen.go
+++ b/generated/v2.34.0/graph_objects/layout_gen.go
@@ -223,7 +223,9 @@ type Layout struct {
 	// arrayOK: false
 	// type: data_array
 	// hiddenlabels is the funnelarea & pie chart analog of visible:'legendonly' but it can contain many labels, and can simultaneously hide slices from several pies/funnelarea charts
-	Hiddenlabels interface{} `json:"hiddenlabels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Hiddenlabels *types.DataArrayType `json:"hiddenlabels,omitempty"`
 
 	// Hiddenlabelssrc
 	// arrayOK: false
@@ -1410,7 +1412,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1422,7 +1426,9 @@ type LayoutColoraxisColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -2861,7 +2867,9 @@ type LayerLine struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the length of dashes and gaps (mapbox.layer.paint.line-dasharray). Has an effect only when `type` is set to *line*.
-	Dash interface{} `json:"dash,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Dash *types.DataArrayType `json:"dash,omitempty"`
 
 	// Dashsrc
 	// arrayOK: false
@@ -3679,7 +3687,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -3921,7 +3931,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -3933,7 +3945,9 @@ type LayoutPolarAngularaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -4253,7 +4267,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -4501,7 +4517,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -4513,7 +4531,9 @@ type LayoutPolarRadialaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5234,7 +5254,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -5499,7 +5521,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -5511,7 +5535,9 @@ type LayoutSceneXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -5814,7 +5840,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -6079,7 +6107,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -6091,7 +6121,9 @@ type LayoutSceneYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -6394,7 +6426,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -6659,7 +6693,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -6671,7 +6707,9 @@ type LayoutSceneZaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -7938,7 +7976,9 @@ type LayoutSmithImaginaryaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Defaults to `realaxis.tickvals` plus the same as negatives and zero.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8170,7 +8210,9 @@ type LayoutSmithRealaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -8599,7 +8641,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -8611,7 +8655,9 @@ type LayoutTernaryAaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9020,7 +9066,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9032,7 +9080,9 @@ type LayoutTernaryBaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -9441,7 +9491,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -9453,7 +9505,9 @@ type LayoutTernaryCaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -10193,7 +10247,9 @@ type LayoutXaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -10735,7 +10791,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -11183,7 +11241,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -11195,7 +11255,9 @@ type LayoutXaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -11367,7 +11429,9 @@ type LayoutYaxisMinor struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -11667,7 +11731,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -12111,7 +12177,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -12123,7 +12191,9 @@ type LayoutYaxis struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/mesh3d_gen.go
+++ b/generated/v2.34.0/graph_objects/mesh3d_gen.go
@@ -96,7 +96,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -115,7 +117,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each face Overrides *color* and *vertexcolor*.
-	Facecolor interface{} `json:"facecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Facecolor *types.DataArrayType `json:"facecolor,omitempty"`
 
 	// Facecolorsrc
 	// arrayOK: false
@@ -175,13 +179,17 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *first* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `i[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `i` represents a point in space, which is the first vertex of a triangle.
-	I interface{} `json:"i,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	I *types.DataArrayType `json:"i,omitempty"`
 
 	// Ids
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -193,7 +201,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the intensity values for vertices or cells as defined by `intensitymode`. It can be used for plotting fields on meshes.
-	Intensity interface{} `json:"intensity,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Intensity *types.DataArrayType `json:"intensity,omitempty"`
 
 	// Intensitymode
 	// arrayOK: false
@@ -218,7 +228,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *second* vertex of a triangle. For example, `{i[m], j[m], k[m]}`  together represent face m (triangle m) in the mesh, where `j[m] = n` points to the triplet `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `j` represents a point in space, which is the second vertex of a triangle.
-	J interface{} `json:"j,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	J *types.DataArrayType `json:"j,omitempty"`
 
 	// Jsrc
 	// arrayOK: false
@@ -230,7 +242,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// A vector of vertex indices, i.e. integer values between 0 and the length of the vertex vectors, representing the *third* vertex of a triangle. For example, `{i[m], j[m], k[m]}` together represent face m (triangle m) in the mesh, where `k[m] = n` points to the triplet  `{x[n], y[n], z[n]}` in the vertex arrays. Therefore, each element in `k` represents a point in space, which is the third vertex of a triangle.
-	K interface{} `json:"k,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	K *types.DataArrayType `json:"k,omitempty"`
 
 	// Ksrc
 	// arrayOK: false
@@ -358,7 +372,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each vertex Overrides *color*. While Red, green and blue colors are in the range of 0 and 255; in the case of having vertex color data in RGBA format, the alpha color should be normalized to be between 0 and 1.
-	Vertexcolor interface{} `json:"vertexcolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Vertexcolor *types.DataArrayType `json:"vertexcolor,omitempty"`
 
 	// Vertexcolorsrc
 	// arrayOK: false
@@ -377,7 +393,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -402,7 +420,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -427,7 +447,9 @@ type Mesh3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices. The nth element of vectors `x`, `y` and `z` jointly represent the X, Y and Z coordinates of the nth vertex.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -849,7 +871,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -861,7 +885,9 @@ type Mesh3dColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/ohlc_gen.go
+++ b/generated/v2.34.0/graph_objects/ohlc_gen.go
@@ -32,7 +32,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the close values.
-	Close interface{} `json:"close,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Close *types.DataArrayType `json:"close,omitempty"`
 
 	// Closesrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -61,7 +65,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the high values.
-	High interface{} `json:"high,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	High *types.DataArrayType `json:"high,omitempty"`
 
 	// Highsrc
 	// arrayOK: false
@@ -103,7 +109,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the low values.
-	Low interface{} `json:"low,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Low *types.DataArrayType `json:"low,omitempty"`
 
 	// Lowsrc
 	// arrayOK: false
@@ -190,7 +200,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the open values.
-	Open interface{} `json:"open,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Open *types.DataArrayType `json:"open,omitempty"`
 
 	// Opensrc
 	// arrayOK: false
@@ -261,7 +273,9 @@ type Ohlc struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates. If absent, linear coordinate will be generated.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/parcats_gen.go
+++ b/generated/v2.34.0/graph_objects/parcats_gen.go
@@ -171,7 +171,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the order in which categories in this dimension appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.
-	Categoryarray interface{} `json:"categoryarray,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Categoryarray *types.DataArrayType `json:"categoryarray,omitempty"`
 
 	// Categoryarraysrc
 	// arrayOK: false
@@ -202,7 +204,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets alternative tick labels for the categories in this dimension. Only has an effect if `categoryorder` is set to *array*. Should be an array the same length as `categoryarray` Used with `categoryorder`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -214,7 +218,9 @@ type ParcatsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the category value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated).
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -796,7 +802,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -808,7 +816,9 @@ type ParcatsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/parcoords_gen.go
+++ b/generated/v2.34.0/graph_objects/parcoords_gen.go
@@ -32,7 +32,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -54,7 +56,9 @@ type Parcoords struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -220,7 +224,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -232,7 +238,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -244,7 +252,9 @@ type ParcoordsDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Dimension values. `values[n]` represents the value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated). Each value must be a finite number.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -826,7 +836,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -838,7 +850,9 @@ type ParcoordsLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/pie_gen.go
+++ b/generated/v2.34.0/graph_objects/pie_gen.go
@@ -38,7 +38,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -146,7 +150,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -262,7 +268,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -333,7 +341,9 @@ type Pie struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values of the sectors. If omitted, we count occurrences of each label.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -857,7 +867,9 @@ type PieMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/pointcloud_gen.go
+++ b/generated/v2.34.0/graph_objects/pointcloud_gen.go
@@ -32,7 +32,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -62,7 +64,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -74,7 +78,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// A sequential value, 0..n, supply it to avoid creating this array inside plotting. If specified, it must be a typed `Int32Array` array. Its length must be equal to or greater than the number of points. For the best performance and memory use, create one large `indices` typed array that is guaranteed to be at least as long as the largest number of points during use, and reuse it on each `Plotly.restyle()` call.
-	Indices interface{} `json:"indices,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Indices *types.DataArrayType `json:"indices,omitempty"`
 
 	// Indicessrc
 	// arrayOK: false
@@ -186,7 +192,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xaxis
 	// arrayOK: false
@@ -198,7 +206,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `xbounds` in the shape of `[xMin, xMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `ybounds` for the performance benefits.
-	Xbounds interface{} `json:"xbounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xbounds *types.DataArrayType `json:"xbounds,omitempty"`
 
 	// Xboundssrc
 	// arrayOK: false
@@ -216,7 +226,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Faster alternative to specifying `x` and `y` separately. If supplied, it must be a typed `Float32Array` array that represents points such that `xy[i * 2] = x[i]` and `xy[i * 2 + 1] = y[i]`
-	Xy interface{} `json:"xy,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Xy *types.DataArrayType `json:"xy,omitempty"`
 
 	// Xysrc
 	// arrayOK: false
@@ -228,7 +240,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yaxis
 	// arrayOK: false
@@ -240,7 +254,9 @@ type Pointcloud struct {
 	// arrayOK: false
 	// type: data_array
 	// Specify `ybounds` in the shape of `[yMin, yMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `xbounds` for the performance benefits.
-	Ybounds interface{} `json:"ybounds,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ybounds *types.DataArrayType `json:"ybounds,omitempty"`
 
 	// Yboundssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/sankey_gen.go
+++ b/generated/v2.34.0/graph_objects/sankey_gen.go
@@ -39,7 +39,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -68,7 +70,9 @@ type Sankey struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -733,7 +737,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each link.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -781,7 +787,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the link.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -798,7 +806,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the source node.
-	Source interface{} `json:"source,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Source *types.DataArrayType `json:"source,omitempty"`
 
 	// Sourcesrc
 	// arrayOK: false
@@ -810,7 +820,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// An integer number `[0..nodes.length - 1]` that represents the target node.
-	Target interface{} `json:"target,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Target *types.DataArrayType `json:"target,omitempty"`
 
 	// Targetsrc
 	// arrayOK: false
@@ -822,7 +834,9 @@ type SankeyLink struct {
 	// arrayOK: false
 	// type: data_array
 	// A numeric value representing the flow volume value.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuesrc
 	// arrayOK: false
@@ -1059,7 +1073,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data to each node.
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -1101,7 +1117,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The shown name of the node.
-	Label interface{} `json:"label,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Label *types.DataArrayType `json:"label,omitempty"`
 
 	// Labelsrc
 	// arrayOK: false
@@ -1130,7 +1148,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized horizontal position of the node.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -1142,7 +1162,9 @@ type SankeyNode struct {
 	// arrayOK: false
 	// type: data_array
 	// The normalized vertical position of the node.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scatter3d_gen.go
+++ b/generated/v2.34.0/graph_objects/scatter3d_gen.go
@@ -38,7 +38,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -107,7 +109,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -290,7 +294,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -315,7 +321,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -340,7 +348,9 @@ type Scatter3d struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -369,13 +379,17 @@ type Scatter3dErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -464,13 +478,17 @@ type Scatter3dErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -559,13 +577,17 @@ type Scatter3dErrorZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1292,7 +1314,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1304,7 +1328,9 @@ type Scatter3dLineColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1864,7 +1890,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1876,7 +1904,9 @@ type Scatter3dMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scatter_gen.go
+++ b/generated/v2.34.0/graph_objects/scatter_gen.go
@@ -50,7 +50,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -163,7 +165,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -364,7 +368,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -420,7 +426,9 @@ type Scatter struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -486,13 +494,17 @@ type ScatterErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -581,13 +593,17 @@ type ScatterErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1474,7 +1490,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1486,7 +1504,9 @@ type ScatterMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scattercarpet_gen.go
+++ b/generated/v2.34.0/graph_objects/scattercarpet_gen.go
@@ -32,7 +32,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the a-axis coordinates.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the b-axis coordinates.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -68,7 +72,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -142,7 +148,9 @@ type Scattercarpet struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -1030,7 +1038,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1042,7 +1052,9 @@ type ScattercarpetMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scattergeo_gen.go
+++ b/generated/v2.34.0/graph_objects/scattergeo_gen.go
@@ -38,7 +38,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -123,7 +125,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -135,7 +139,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -188,7 +194,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the coordinates via location IDs or names. Coordinates correspond to the centroid of each location given. See `locationmode` for more info.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -200,7 +208,9 @@ type Scattergeo struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -1011,7 +1021,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1023,7 +1035,9 @@ type ScattergeoMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scattergl_gen.go
+++ b/generated/v2.34.0/graph_objects/scattergl_gen.go
@@ -38,7 +38,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -302,7 +306,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -358,7 +364,9 @@ type Scattergl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false
@@ -418,13 +426,17 @@ type ScatterglErrorX struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -513,13 +525,17 @@ type ScatterglErrorY struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar. Values are plotted relative to the underlying data.
-	Array interface{} `json:"array,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Array *types.DataArrayType `json:"array,omitempty"`
 
 	// Arrayminus
 	// arrayOK: false
 	// type: data_array
 	// Sets the data corresponding the length of each error bar in the bottom (left) direction for vertical (horizontal) bars Values are plotted relative to the underlying data.
-	Arrayminus interface{} `json:"arrayminus,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Arrayminus *types.DataArrayType `json:"arrayminus,omitempty"`
 
 	// Arrayminussrc
 	// arrayOK: false
@@ -1276,7 +1292,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1288,7 +1306,9 @@ type ScatterglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scattermapbox_gen.go
+++ b/generated/v2.34.0/graph_objects/scattermapbox_gen.go
@@ -49,7 +49,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -128,7 +132,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the latitude coordinates (in degrees North).
-	Lat interface{} `json:"lat,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lat *types.DataArrayType `json:"lat,omitempty"`
 
 	// Latsrc
 	// arrayOK: false
@@ -174,7 +180,9 @@ type Scattermapbox struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the longitude coordinates (in degrees East).
-	Lon interface{} `json:"lon,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Lon *types.DataArrayType `json:"lon,omitempty"`
 
 	// Lonsrc
 	// arrayOK: false
@@ -1043,7 +1051,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1055,7 +1065,9 @@ type ScattermapboxMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scatterpolar_gen.go
+++ b/generated/v2.34.0/graph_objects/scatterpolar_gen.go
@@ -44,7 +44,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -130,7 +132,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -212,7 +216,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -300,7 +306,9 @@ type Scatterpolar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -1049,7 +1057,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1061,7 +1071,9 @@ type ScatterpolarMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scatterpolargl_gen.go
+++ b/generated/v2.34.0/graph_objects/scatterpolargl_gen.go
@@ -38,7 +38,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -117,7 +119,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -199,7 +203,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the radial coordinates
-	R interface{} `json:"r,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	R *types.DataArrayType `json:"r,omitempty"`
 
 	// R0
 	// arrayOK: false
@@ -287,7 +293,9 @@ type Scatterpolargl struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the angular coordinates
-	Theta interface{} `json:"theta,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Theta *types.DataArrayType `json:"theta,omitempty"`
 
 	// Theta0
 	// arrayOK: false
@@ -1012,7 +1020,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1024,7 +1034,9 @@ type ScatterpolarglMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scattersmith_gen.go
+++ b/generated/v2.34.0/graph_objects/scattersmith_gen.go
@@ -44,7 +44,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -118,7 +120,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -130,7 +134,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Imag interface{} `json:"imag,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Imag *types.DataArrayType `json:"imag,omitempty"`
 
 	// Imagsrc
 	// arrayOK: false
@@ -212,7 +218,9 @@ type Scattersmith struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.
-	Real interface{} `json:"real,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Real *types.DataArrayType `json:"real,omitempty"`
 
 	// Realsrc
 	// arrayOK: false
@@ -1018,7 +1026,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1030,7 +1040,9 @@ type ScattersmithMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/scatterternary_gen.go
+++ b/generated/v2.34.0/graph_objects/scatterternary_gen.go
@@ -32,7 +32,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	A interface{} `json:"a,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	A *types.DataArrayType `json:"a,omitempty"`
 
 	// Asrc
 	// arrayOK: false
@@ -44,7 +46,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	B interface{} `json:"b,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	B *types.DataArrayType `json:"b,omitempty"`
 
 	// Bsrc
 	// arrayOK: false
@@ -56,7 +60,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary<i>.sum`.
-	C interface{} `json:"c,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	C *types.DataArrayType `json:"c,omitempty"`
 
 	// Cliponaxis
 	// arrayOK: false
@@ -80,7 +86,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -154,7 +162,9 @@ type Scatterternary struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -1036,7 +1046,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1048,7 +1060,9 @@ type ScatterternaryMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/splom_gen.go
+++ b/generated/v2.34.0/graph_objects/splom_gen.go
@@ -32,7 +32,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -96,7 +98,9 @@ type Splom struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -319,7 +323,9 @@ type SplomDimension struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the dimension values to be plotted.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -985,7 +991,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -997,7 +1005,9 @@ type SplomMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/streamtube_gen.go
+++ b/generated/v2.34.0/graph_objects/streamtube_gen.go
@@ -79,7 +79,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -127,7 +129,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -254,7 +258,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the vector field.
-	U interface{} `json:"u,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	U *types.DataArrayType `json:"u,omitempty"`
 
 	// Uhoverformat
 	// arrayOK: false
@@ -284,7 +290,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the vector field.
-	V interface{} `json:"v,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	V *types.DataArrayType `json:"v,omitempty"`
 
 	// Vhoverformat
 	// arrayOK: false
@@ -309,7 +317,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the vector field.
-	W interface{} `json:"w,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	W *types.DataArrayType `json:"w,omitempty"`
 
 	// Whoverformat
 	// arrayOK: false
@@ -327,7 +337,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates of the vector field.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -345,7 +357,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates of the vector field.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -363,7 +377,9 @@ type Streamtube struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates of the vector field.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -778,7 +794,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -790,7 +808,9 @@ type StreamtubeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1188,7 +1208,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x components of the starting position of the streamtubes
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xsrc
 	// arrayOK: false
@@ -1200,7 +1222,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y components of the starting position of the streamtubes
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ysrc
 	// arrayOK: false
@@ -1212,7 +1236,9 @@ type StreamtubeStarts struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z components of the starting position of the streamtubes
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zsrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/sunburst_gen.go
+++ b/generated/v2.34.0/graph_objects/sunburst_gen.go
@@ -46,7 +46,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -129,7 +133,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -215,7 +221,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -249,7 +257,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -302,7 +312,9 @@ type Sunburst struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -1123,7 +1135,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1135,7 +1149,9 @@ type SunburstMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1361,7 +1377,9 @@ type SunburstMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/surface_gen.go
+++ b/generated/v2.34.0/graph_objects/surface_gen.go
@@ -90,7 +90,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -150,7 +152,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -260,7 +264,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the surface color values, used for setting a color scale independent of `z`.
-	Surfacecolor interface{} `json:"surfacecolor,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Surfacecolor *types.DataArrayType `json:"surfacecolor,omitempty"`
 
 	// Surfacecolorsrc
 	// arrayOK: false
@@ -303,7 +309,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xcalendar
 	// arrayOK: false
@@ -328,7 +336,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Ycalendar
 	// arrayOK: false
@@ -353,7 +363,9 @@ type Surface struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the z coordinates.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zcalendar
 	// arrayOK: false
@@ -775,7 +787,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -787,7 +801,9 @@ type SurfaceColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/table_gen.go
+++ b/generated/v2.34.0/graph_objects/table_gen.go
@@ -37,7 +37,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the rendered order of the data columns; for example, a value `2` at position `0` means that column index `0` in the data will be rendered as the third column, as columns have an index base of zero.
-	Columnorder interface{} `json:"columnorder,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Columnorder *types.DataArrayType `json:"columnorder,omitempty"`
 
 	// Columnordersrc
 	// arrayOK: false
@@ -61,7 +63,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -101,7 +105,9 @@ type Table struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -365,7 +371,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -412,7 +420,9 @@ type TableCells struct {
 	// arrayOK: false
 	// type: data_array
 	// Cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -639,7 +649,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the cell value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-	Format interface{} `json:"format,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Format *types.DataArrayType `json:"format,omitempty"`
 
 	// Formatsrc
 	// arrayOK: false
@@ -686,7 +698,9 @@ type TableHeader struct {
 	// arrayOK: false
 	// type: data_array
 	// Header cell values. `values[m][n]` represents the value of the `n`th point in column `m`, therefore the `values[m]` vector length for all columns must be the same (longer vectors will be truncated). Each value must be a finite number or a string.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/treemap_gen.go
+++ b/generated/v2.34.0/graph_objects/treemap_gen.go
@@ -46,7 +46,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -105,7 +107,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -122,7 +126,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the labels of each of the sectors.
-	Labels interface{} `json:"labels,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Labels *types.DataArrayType `json:"labels,omitempty"`
 
 	// Labelssrc
 	// arrayOK: false
@@ -203,7 +209,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.
-	Parents interface{} `json:"parents,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Parents *types.DataArrayType `json:"parents,omitempty"`
 
 	// Parentssrc
 	// arrayOK: false
@@ -236,7 +244,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets text elements associated with each sector. If trace `textinfo` contains a *text* flag, these elements will be seen on the chart. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.
-	Text interface{} `json:"text,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Text *types.DataArrayType `json:"text,omitempty"`
 
 	// Textfont
 	// arrayOK: false
@@ -301,7 +311,9 @@ type Treemap struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values associated with each of the sectors. Use with `branchvalues` to determine how the values are summed.
-	Values interface{} `json:"values,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Values *types.DataArrayType `json:"values,omitempty"`
 
 	// Valuessrc
 	// arrayOK: false
@@ -1112,7 +1124,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -1124,7 +1138,9 @@ type TreemapMarkerColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1378,7 +1394,9 @@ type TreemapMarker struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the color of each sector of this trace. If not specified, the default trace color set is used to pick the sector colors.
-	Colors interface{} `json:"colors,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Colors *types.DataArrayType `json:"colors,omitempty"`
 
 	// Colorscale
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/violin_gen.go
+++ b/generated/v2.34.0/graph_objects/violin_gen.go
@@ -49,7 +49,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -116,7 +118,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -337,7 +341,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x sample data or coordinates. See overview for more info.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -367,7 +373,9 @@ type Violin struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y sample data or coordinates. See overview for more info.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/volume_gen.go
+++ b/generated/v2.34.0/graph_objects/volume_gen.go
@@ -89,7 +89,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -149,7 +151,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -310,7 +314,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the 4th dimension (value) of the vertices.
-	Value interface{} `json:"value,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Value *types.DataArrayType `json:"value,omitempty"`
 
 	// Valuehoverformat
 	// arrayOK: false
@@ -335,7 +341,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the X coordinates of the vertices on X axis.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// Xhoverformat
 	// arrayOK: false
@@ -353,7 +361,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Y coordinates of the vertices on Y axis.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Yhoverformat
 	// arrayOK: false
@@ -371,7 +381,9 @@ type Volume struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the Z coordinates of the vertices on Z axis.
-	Z interface{} `json:"z,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Z *types.DataArrayType `json:"z,omitempty"`
 
 	// Zhoverformat
 	// arrayOK: false
@@ -853,7 +865,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.
-	Ticktext interface{} `json:"ticktext,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ticktext *types.DataArrayType `json:"ticktext,omitempty"`
 
 	// Ticktextsrc
 	// arrayOK: false
@@ -865,7 +879,9 @@ type VolumeColorbar struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.
-	Tickvals interface{} `json:"tickvals,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Tickvals *types.DataArrayType `json:"tickvals,omitempty"`
 
 	// Tickvalssrc
 	// arrayOK: false
@@ -1291,7 +1307,9 @@ type VolumeSlicesX struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis x except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1319,7 +1337,9 @@ type VolumeSlicesY struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis y except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false
@@ -1347,7 +1367,9 @@ type VolumeSlicesZ struct {
 	// arrayOK: false
 	// type: data_array
 	// Specifies the location(s) of slices on the axis. When not specified slices would be created for all points of the axis z except start and end.
-	Locations interface{} `json:"locations,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Locations *types.DataArrayType `json:"locations,omitempty"`
 
 	// Locationssrc
 	// arrayOK: false

--- a/generated/v2.34.0/graph_objects/waterfall_gen.go
+++ b/generated/v2.34.0/graph_objects/waterfall_gen.go
@@ -62,7 +62,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements
-	Customdata interface{} `json:"customdata,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Customdata *types.DataArrayType `json:"customdata,omitempty"`
 
 	// Customdatasrc
 	// arrayOK: false
@@ -133,7 +135,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.
-	Ids interface{} `json:"ids,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Ids *types.DataArrayType `json:"ids,omitempty"`
 
 	// Idssrc
 	// arrayOK: false
@@ -191,7 +195,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// An array containing types of values. By default the values are considered as 'relative'. However; it is possible to use 'total' to compute the sums. Also 'absolute' could be applied to reset the computed total or to declare an initial value where needed.
-	Measure interface{} `json:"measure,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Measure *types.DataArrayType `json:"measure,omitempty"`
 
 	// Measuresrc
 	// arrayOK: false
@@ -370,7 +376,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the x coordinates.
-	X interface{} `json:"x,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	X *types.DataArrayType `json:"x,omitempty"`
 
 	// X0
 	// arrayOK: false
@@ -419,7 +427,9 @@ type Waterfall struct {
 	// arrayOK: false
 	// type: data_array
 	// Sets the y coordinates.
-	Y interface{} `json:"y,omitempty"`
+	// use types.DataArray to pass any slice of data
+	// use types.BDataArray to pass data in binary format as provided by numpy
+	Y *types.DataArrayType `json:"y,omitempty"`
 
 	// Y0
 	// arrayOK: false

--- a/generator/renderer.go
+++ b/generator/renderer.go
@@ -613,7 +613,7 @@ func (r *Renderer) WriteUnmarshalTests(w io.Writer) error {
 
 // valTypeMap maps between ValTypes and go types
 var valTypeMap = map[ValType]string{
-	ValTypeDataArray:  "interface{}",
+	ValTypeDataArray:  "*types.DataArrayType",
 	ValTypeEnum:       "NO-TYPE",
 	ValTypeBoolean:    "types.Bool",
 	ValTypeNumber:     "float64",

--- a/generator/typefile.go
+++ b/generator/typefile.go
@@ -198,6 +198,23 @@ func (file *typeFile) parseAttributes(namePrefix string, typePrefix string, attr
 				},
 			})
 
+		case attr.ValType == ValTypeDataArray:
+			typeName := valTypeMap[attr.ValType]
+
+			fields = append(fields, structField{
+				Name:     xstrings.ToCamelCase(attr.Name),
+				JSONName: attr.Name,
+				Type:     typeName,
+				Description: []string{
+					// fmt.Sprintf("default: %s", attr.Dflt),
+					fmt.Sprintf("arrayOK: %t", attr.ArrayOK),
+					fmt.Sprintf("type: %s", attr.ValType),
+					attr.Description,
+					fmt.Sprint("use types.DataArray to pass any slice of data"),
+					fmt.Sprint("use types.BDataArray to pass data in binary format as provided by numpy"),
+				},
+			})
+
 		default:
 			typeName := valTypeMap[attr.ValType]
 

--- a/pkg/types/data_array.go
+++ b/pkg/types/data_array.go
@@ -1,0 +1,193 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// DataArrayType An {array} of data.
+// The value must represent an {array} or it will be ignored, but this array can be provided in several forms:
+// (1) a regular {array} object
+// (2) a typed array (e.g. Float32Array)
+// (3) an object with keys dtype, bdata, and optionally shape.
+// In this 3rd form, dtype is one of *f8*, *f4*. *i4*, *u4*, *i2*, *u2*, *i1*, *u1* or *u1c* for Uint8ClampedArray.
+// In addition to shorthand `dtype` above one could also use the following forms: *float64*, *float32*, *int32*, *uint32*, *int16*, *uint16*, *int8*, *uint8* or *uint8c*  for Uint8ClampedArray.
+// `bdata` is either a base64-encoded string or the ArrayBuffer of an integer or float typed array.
+// For either multi-dimensional arrays you must also provide its dimensions separated by comma via `shape`.
+// For example using `dtype`: *f4* and `shape`: *5,100* you can declare a 2-D array that has 5 rows and 100 columns containing
+// float32 values i.e. 4 bits per value. `shape` is optional for one dimensional arrays.",
+type DataArrayType struct {
+	// Option 1
+	values interface{}
+
+	// Option 2 // doesn't apply in go as option one already has types
+
+	// Option 3
+	dtype DType
+	// Base64 encoded data
+	bdata []byte
+	shape DataArrayShape
+}
+
+type BDataArrayType struct {
+	Dtype DType          `json:"dtype,omitempty"`
+	Bdata []byte         `json:"bdata,omitempty"`
+	Shape DataArrayShape `json:"shape,omitempty"`
+}
+
+// Value returns either the underlying interface values OR the BDataArrayType, depending on how the DataArray was created.
+func (da *DataArrayType) Value() interface{} {
+	if da.values != nil {
+		return da.values
+	}
+	return BDataArrayType{
+		Dtype: da.dtype,
+		Bdata: da.bdata,
+		Shape: da.shape,
+	}
+}
+
+type DataArrayShape []int
+
+type DType string
+
+const (
+	DTypeFloat64 DType = "float64"
+	DTypeFloat32 DType = "float32"
+	DTypeInt32   DType = "int32"
+	DTypeUInt32  DType = "uint32"
+	DTypeInt16   DType = "int16"
+	DTypeUInt16  DType = "uint16"
+	DTypeInt8    DType = "int8"
+	DTypeUInt8   DType = "uint8"
+	DTypeUInt8c  DType = "uint8c"
+)
+
+func DataArray[T any](data []T) *DataArrayType {
+	return &DataArrayType{
+		values: data,
+	}
+}
+
+func BDataArray(dtype DType, bdata []byte, shape []int) *DataArrayType {
+	return &DataArrayType{
+		dtype: dtype,
+		bdata: bdata,
+		shape: shape,
+	}
+}
+
+func (d *DataArrayType) MarshalJSON() ([]byte, error) {
+	if d.values != nil {
+		// If Values is not nil, marshal it directly
+		return json.Marshal(d.values)
+	}
+
+	return json.Marshal(BDataArrayType{
+		Dtype: d.dtype,
+		Bdata: d.bdata,
+		Shape: d.shape,
+	})
+}
+
+func (d *DataArrayType) UnmarshalJSON(data []byte) error {
+
+	bData := &BDataArrayType{}
+	err := json.Unmarshal(data, bData)
+	if err == nil {
+		d.bdata = bData.Bdata
+		d.dtype = bData.Dtype
+		d.shape = bData.Shape
+		return nil
+	}
+
+	values, err := unmarshalToGenericSlice(data)
+	if err != nil {
+		return err
+	}
+	d.values = values
+	return nil
+}
+
+// unmarshalToGenericSlice unmarshals JSON data into a generic slice.
+// It returns the data as a slice of interface{} and its detected type.
+func unmarshalToGenericSlice(data []byte) (interface{}, error) {
+	var genericSlice []interface{}
+	if err := json.Unmarshal(data, &genericSlice); err != nil {
+		return nil, err
+	}
+
+	if len(genericSlice) == 0 {
+		return genericSlice, nil
+	}
+
+	// Determine the type of elements in the slice
+	elemType := reflect.TypeOf(genericSlice[0])
+	return convertToType(genericSlice, elemType.Kind())
+}
+
+// Convert a slice of interface{} to a slice of the detected type
+func convertToType(slice []interface{}, elemType reflect.Kind) (interface{}, error) {
+	switch elemType {
+	// I believe json package will never use this type, but will use float64
+	case reflect.Int:
+		intSlice := make([]int, len(slice))
+		for i, v := range slice {
+			if v, ok := v.(float64); ok { // JSON numbers are float64 by default
+				intSlice[i] = int(v)
+			} else {
+				return nil, fmt.Errorf("unexpected type %T for int", v)
+			}
+		}
+		return intSlice, nil
+	case reflect.Float64:
+		floatSlice := make([]float64, len(slice))
+		for i, v := range slice {
+			if v, ok := v.(float64); ok {
+				floatSlice[i] = v
+			} else {
+				return nil, fmt.Errorf("unexpected type %T for float64", v)
+			}
+		}
+		return floatSlice, nil
+	case reflect.String:
+		stringSlice := make([]string, len(slice))
+		for i, v := range slice {
+			if v, ok := v.(string); ok {
+				stringSlice[i] = v
+			} else {
+				return nil, fmt.Errorf("unexpected type %T for string", v)
+			}
+		}
+		return stringSlice, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %s", elemType)
+	}
+}
+
+func (d DataArrayShape) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal([]int(d))
+	if err != nil {
+		return b, err
+	}
+	// make data compatible with what plotty expects
+	b = bytes.Replace(b, []byte("["), []byte("\""), -1)
+	b = bytes.Replace(b, []byte("]"), []byte("\""), -1)
+
+	return b, nil
+}
+
+func (d *DataArrayShape) UnmarshalJSON(data []byte) error {
+	data = bytes.Replace(data, []byte("\""), []byte("["), 1)
+	data = bytes.Replace(data, []byte("\""), []byte("]"), 1)
+
+	intSlice := []int{}
+	err := json.Unmarshal(data, &intSlice)
+	if err != nil {
+		return err
+	}
+	(*d) = intSlice
+	return nil
+}

--- a/pkg/types/data_array_test.go
+++ b/pkg/types/data_array_test.go
@@ -1,0 +1,130 @@
+package types_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/MetalBlueberry/go-plotly/pkg/types"
+	. "github.com/onsi/gomega"
+)
+
+var testSomeEncodedDataString = "SomeEncodedData"
+var testSomeEncodedDataBytes = []byte("SomeEncodedData")
+var testSomeEncodedData = base64.StdEncoding.EncodeToString([]byte(testSomeEncodedDataString))
+
+func TestDataArrayType_MarshalJSON(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     *types.DataArrayType
+		expected string
+	}{
+		{
+			name:     "Marshal with values",
+			data:     types.DataArray([]int{1, 2, 3}),
+			expected: `[1,2,3]`,
+		},
+		{
+			name:     "Marshal with bdata",
+			data:     types.BDataArray(types.DTypeFloat32, testSomeEncodedDataBytes, []int{2, 2}),
+			expected: fmt.Sprintf(`{"dtype":"float32","bdata":"%s","shape":"2,2"}`, testSomeEncodedData),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.data.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+			if string(b) != tt.expected {
+				t.Errorf("MarshalJSON() = %v, want %v", string(b), tt.expected)
+			}
+		})
+	}
+}
+
+func TestDataArrayType_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected *types.DataArrayType
+	}{
+		{
+			name:     "Unmarshal with values",
+			data:     `[1,2,3]`,
+			expected: types.DataArray([]float64{1, 2, 3}),
+		},
+		{
+			name:     "Unmarshal with bdata",
+			data:     fmt.Sprintf(`{"dtype":"float32","bdata":"%s","shape":"2,2"}`, testSomeEncodedData),
+			expected: types.BDataArray(types.DTypeFloat32, testSomeEncodedDataBytes, []int{2, 2}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := &types.DataArrayType{}
+			if err := json.Unmarshal([]byte(tt.data), got); err != nil {
+				t.Fatalf("UnmarshalJSON() error = %v", err)
+			}
+			g.Expect(tt.expected).To(Equal(got))
+		})
+	}
+}
+
+func TestDataArrayShape_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     types.DataArrayShape
+		expected string
+	}{
+		{
+			name:     "Marshal shape",
+			data:     types.DataArrayShape{2, 3, 4},
+			expected: `"2,3,4"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.data.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+			if string(b) != tt.expected {
+				t.Errorf("MarshalJSON() = %v, want %v", string(b), tt.expected)
+			}
+		})
+	}
+}
+
+func TestDataArrayShape_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected types.DataArrayShape
+	}{
+		{
+			name:     "Unmarshal shape",
+			data:     `"2,3,4"`,
+			expected: types.DataArrayShape{2, 3, 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got types.DataArrayShape
+			if err := json.Unmarshal([]byte(tt.data), &got); err != nil {
+				t.Fatalf("UnmarshalJSON() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("UnmarshalJSON() = %+v, want %+v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Here we go again!

This time I'm adding the DataArray type to add a bit more type safety to the package

it also adds full support for numpy array format. Just because the plotly spec specifies it is supported and doing it early will ease changes later in the package.